### PR TITLE
Replace OpenNIC with OpenDNS, which fits as a better replacement for Goo...

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,11 +313,11 @@
           <td class="free">
             <ul>
               <li>
-                <a class="logo" href="http://www.opennicproject.org/"><img src="assets/img/free/opennic.png" alt="" /></a>
-                <a class="name" href="http://www.opennicproject.org/">
-                  <span class="title">OpenNIC Project</span>
+                <a class="logo" href="http://www.opendns.com/"><img src="http://www.opendns.com/download.php?f=150x59.png" alt="" /></a>
+                <a class="name" href="http://www.opendns.com/">
+                  <span class="title">OpenDNS</span>
                   <span class="desc">
-                    <span class="i18n-opennic-desc">Total DNS neutrality.</span>
+                    <span class="i18n-opendns-desc">Highly secure DNS with a strong anti-censorship/pro-privacy policy.</span>
                   </span>
                 </a>
               </li>


### PR DESCRIPTION
OpenNIC is more politically motivated to operate rouge TLDs vs actually providing secure and reliable DNS resolution. Replace it with OpenDNS which is ran by the good guys. http://www.opendns.com/about/anti-censorship-policy
