### PR TITLE
correcciones varias

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -1,7 +1,7 @@
-{
+"{
   "i18n-action-center": "Centro de Acción",
 
-  "i18n-intro": "<strong>No optes por PRISM, El programa de vigilancia de datos mundial de la NSA.</strong> Para de reportar tus actividades online al gobierno de los EEUU con estas alternativas libres y gratuitas al software privativo.",
+  "i18n-intro": "<strong>No optes por PRISM, El programa de vigilancia de datos mundial de la NSA.</strong> Deja de reportar tus actividades online al gobierno de los EEUU con estas alternativas libres y gratuitas al software privativo.",
 
 
 
@@ -10,7 +10,7 @@
   "i18n-debian-desc": "Popular distribución de GNU/Linux famosa por su contrato social.",
   "i18n-fedora-desc": "Distribución de GNU/Linux rápida, estable y potente.",
   "i18n-bsd-desc": "FreeBSD, OpenBSD, NetBSD, PC-BSD.",
-  "i18n-tails-desc": "Live CD/USB diseñado para asegurar la privacidad.",
+  "i18n-tails-desc": "CD y USB vivos diseñado para asegurar la privacidad.",
   "i18n-trisquel-desc": "Distribución de GNU/Linux amigable para el usuario, patrocinada por la FSF.",
 
 
@@ -18,12 +18,12 @@
   "i18n-web-browser": "Navegador Web",
   "i18n-icecat-desc": "Versión GNU de Firefox.",
   "i18n-firefox-desc": "Navegador web de fuente libre y abierta.",
-  "i18n-torbrowser-desc": "Navegación encriptada y anónima.",
+  "i18n-torbrowser-desc": "Navegación cifrada y anónima.",
 
 
 
   "i18n-web-browser-plugins": "Plugins para navegadores web",
-  "i18n-httpseverywhere-desc": "Encripta tus comunicaciones en millones de sitios.",
+  "i18n-httpseverywhere-desc": "Cifra tus comunicaciones en millones de sitios.",
   "i18n-fixtracking-desc": "Guía para para de ser monitoreado online.",
   "i18n-torbutton-desc": "Tor plugin para IceCat y Firefox.",
 
@@ -59,7 +59,7 @@
 
 
   "i18n-email-services": "Servicios de Email",
-  "i18n-bitmessage-desc": "Servidor de email encriptado y descentralizado.",
+  "i18n-bitmessage-desc": "Servidor de email Cifrado y descentralizado.",
   "i18n-riseup-desc": "Cuentas de email seguras y privadas.",
 
 
@@ -73,10 +73,10 @@
 
 
 
-  "i18n-email-encryption": "Encriptación correo electrónico",
-  "i18n-enigmail-desc": "Un plugin OpenPGP para Thunderbird/Icedove.",
+  "i18n-email-encryption": "Cifrado de correo electrónico",
+  "i18n-enigmail-desc": "Un plugin de OpenPGP para Thunderbird/Icedove.",
   "i18n-gnuprivacyguard-desc": "Implementación libre y gratuita de OpenPGP.",
-  "i18n-mailvelope-desc": "Encriptación OpenPGP para webmail.",
+  "i18n-mailvelope-desc": "Cifra de OpenPGP para webmail.",
   "i18n-webpg-desc": "GnuPG/PGP en tu navegador.",
 
 
@@ -95,36 +95,36 @@
 
 
   "i18n-social-networking": "Redes sociales",
-  "i18n-buddycloud-desc": "Open source, federated social network.",
+  "i18n-buddycloud-desc": "Red social federada, codigo abierto.",
   "i18n-diaspora-desc": "Red social distribuida conducida comunitariamente.",
   "i18n-friendica-desc": "Servidor web social libre y gratuito.",
   "i18n-gnusocial-desc": "Red social descentralizada y autohospedada.",
-  "i18n-lorea-desc": "Distributed and federated social nodes.",
+  "i18n-lorea-desc": "Distribuido y federados nodos sociales.",
   "i18n-movim-desc": "Servidor de red social descentralizado.",
   "i18n-pumpio-desc": "Servidor stream social autohospedado.",
-  "i18n-salutatoi-desc": "Multi-frontend, multipurpose communication tool.",
-  "i18n-tent-desc": "Protocolo de red autónomo social libre.",
+  "i18n-salutatoi-desc": "Herramientas de comunicación multipropósito, con varias interfaces.",
+  "i18n-tent-desc": "Protocolo para red autónomo social libre.",
 
 
 
   "i18n-instant-messaging": "Mensajería instantánea",
-  "i18n-cryptocat-desc": "Conversaciones online privadas y encriptadas.",
-  "i18n-otr-desc": "Instalar y habilitar en Pidgin para encriptar el chat.",
-  "i18n-pidgin-desc": "Programa de chat de fuente abierta.",
+  "i18n-cryptocat-desc": "Conversaciones online privadas y Cifradas.",
+  "i18n-otr-desc": "Instalar y habilitar en Pidgin para Cifrar el chat.",
+  "i18n-pidgin-desc": "Programa de chat de codigo abierta.",
   "i18n-adium-desc": "Pidgin para OS X (recuerda de habilitar OTR).",
   "i18n-retroshare-desc": "Plataforma de comunicaciones P2P libre y segura.",
 
 
 
   "i18n-video-voip": "Videoconferencia/VOIP",
-  "i18n-jitsi-desc": "Texto y video chat encriptado.",
-  "i18n-linphone-desc": "Encrypted voice and video client.",
-  "i18n-mumble-desc": "Chat de voz encriptado de baja latencia.",
+  "i18n-jitsi-desc": "Texto, audio y video chat cifrado.",
+  "i18n-linphone-desc": "Telefonia online (VOIP) cifrado, con soporte para audio y video.",
+  "i18n-mumble-desc": "Chat de voz cifrado de baja latencia.",
 
 
 
   "i18n-media-publishing": "Publicación de medios",
-  "i18n-gnumediagoblin-desc": "Plataforma descentralizada de media publishing.",
+  "i18n-gnumediagoblin-desc": "Plataforma descentralizada de publicación de medios.",
   "i18n-piwigo-desc": "Plataforma de álbumes de fotos libre y gratuito.",
   "i18n-wordpress-desc": "Sitio web/blog CMS libre y gratuito.",
   "i18n-zenphoto-desc": "Fotoblog CMS libre y gratuito.",
@@ -137,8 +137,8 @@
 
 
 
-  "i18n-web-analytics": "Analítica Web",
-  "i18n-piwik-desc": "Analítica web libre y gratuita autohospedada.",
+  "i18n-web-analytics": "Análisis web",
+  "i18n-piwik-desc": "Análisis web, libre y gratuita autohosteado.",
 
 
 
@@ -148,11 +148,11 @@
   
 
   "i18n-android-app-store": "Android App Store",
-  "i18n-fdroid-desc": "Free and open source apps for Android.",
+  "i18n-fdroid-desc": "Aplicaciones libres y código abierto para Android.",
 
 
 
-  "i18n-csipsimple-desc": "VOIP encriptado y gratis para Android.",
+  "i18n-csipsimple-desc": "VOIP cifrado y gratis para Android.",
   "i18n-gibberbot-desc": "Mensajes privados mediante OTR para Android.",
   "i18n-orbot-desc": "TOR para Android.",
   "i18n-redphone-desc": "Llamadas seguras y privadas para Android.",
@@ -163,7 +163,7 @@
 
 
   "i18n-ios-insecure-desc": "iOS devices contain hardware tracking.",
-  "i18n-chatsecure-desc": "IM encriptado para iOS.",
+  "i18n-chatsecure-desc": "IM Cifrado para iOS.",
   "i18n-onionbrowser-desc": "Navegación segura para iOS.",
 
 


### PR DESCRIPTION
- En español no es encriptar si no cifrar, encriptar es un barbarismo
- Traduje algunos textos
- Cambie "para" por "deja" por que tiene doble sentido en español
