### PR TITLE
lang-es: Correct syntax error; complete some translations

### DIFF
--- a/lang/es.json
+++ b/lang/es.json
@@ -1,4 +1,4 @@
-"{
+{
   "i18n-action-center": "Centro de Acción",
 
   "i18n-intro": "<strong>No optes por PRISM, El programa de vigilancia de datos mundial de la NSA.</strong> Deja de reportar tus actividades online al gobierno de los EEUU con estas alternativas libres y gratuitas al software privativo.",
@@ -188,15 +188,15 @@
 
 
   "i18n-media-title": "Menciones en los medios.",
-  "i18n-catalan": "Catalan",
+  "i18n-catalan": "Catalán",
   "i18n-dutch": "Holandés",
   "i18n-english": "Inglés",
   "i18n-french": "Francés",
   "i18n-german": "Alemán",
-  "i18n-italian": "Italian",
+  "i18n-italian": "Italiano",
   "i18n-polish": "Polaco",
   "i18n-spanish": "Español",
-  "i18n-chinese-traditional": "Chinese (Traditional)",
+  "i18n-chinese-traditional": "Chino (Tradicional)",
 
 
 


### PR DESCRIPTION
An `"` at the beginning invalidated the rest of the syntax.
Also some translations were missing. I'll probably take
a closer look later.
