### PR TITLE
Remove references to Torbutton.

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,6 @@
                 </a>
                 <span class="desc">
                   <span class="i18n-icecat-desc">GNU version of Firefox.</span>
-                  <span class="fs"><span class="i18n-add">add</span>-torbutton</span>
                 </span>
               </li>
               <li>
@@ -183,7 +182,6 @@
                 </a>
                 <span class="desc">
                   <span class="i18n-firefox-desc">Open source web browser.</span>
-                  <span class="fs"><span class="i18n-add">add</span>-torbutton</span>
                   <span class="fs"><span class="i18n-rec-non-free">recommends non-free addons*</span></span>
                 </span>
               </li>
@@ -245,16 +243,6 @@
                 </a>
                 <span class="desc">
                   <span class="i18n-noscript-desc">Only enable JavaScript, Java, and Flash for sites you trust.</span>
-                </span>
-              </li>
-              <li>
-                <a class="logo" href="https://www.torproject.org/index.html.en"><img src="assets/img/free/tor.png" alt="" /></a>
-                <a class="name" href="https://www.torproject.org/index.html.en">
-                  <span class="title">Torbutton</span>
-                </a>
-                <span class="desc">
-                  <span class="i18n-torbutton-desc">Tor plugin for IceCat and Firefox.</span>
-                  <span class="fs"><span class="i18n-advanced">advanced</span></span>
                 </span>
               </li>
             </ul>


### PR DESCRIPTION
The use of Torbutton is not recommended. There is no known safe way to switch between Tor and non-Tor contexts in the same browsing session. Instead, independently use TorBrowser and another browser of your choice.
