### PR TITLE
Ignore vim swap files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .DS_Store
 *~
-*.swo
-*.swp
-*.swn
+.*.s[a-w][a-z]


### PR DESCRIPTION
Updating .gitignore with a more global ignore rule. This rule is taking from [GitHub’s own `vim.gitignore` file](https://github.com/github/gitignore/blob/master/Global/vim.gitignore).
