### PR TITLE
Patch 9

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -199,7 +199,7 @@
 
 
   "i18n-fsf-definition-title": "*Diese Website verwendet die <strong>Free Software Foundation</strong>-Definition für freie Software.",
-  "i18n-fsf-quote": "&ldquo; Freie Software ist Software, die die Freiheit und Gemeinschaft der Nutzer respektiert. Ganz allgemein gesagt, haben <strong>Nutzer die Freiheit, Software auszuführen, zu kopieren, zu verbreiten, zu untersuchen, zu ändern und zu verbessern.</strong> Mit diesen Freiheiten kontrollieren die Nutzer (sowohl einzeln als auch im kollektiv) das Programm und was es für sie ausführt.",
+  "i18n-fsf-quote": "&ldquo;Freie Software ist Software, die die Freiheit und Gemeinschaft der Nutzer respektiert. Ganz allgemein gesagt, haben <strong>Nutzer die Freiheit, Software auszuführen, zu kopieren, zu verbreiten, zu untersuchen, zu ändern und zu verbessern.</strong> Mit diesen Freiheiten kontrollieren die Nutzer (sowohl einzeln als auch im kollektiv) das Programm und was es für sie ausführt.",
 
 
   "i18n-eff-title": "Trete in Aktion gegen PRISM im <strong>Electronic Frontier Foundation</strong> Action Center.",


### PR DESCRIPTION
Hi Zhong,

I replaced the verbatim translated free software definition with the official one. 

Btw, you could offer an "url hook" to the single definitions within the language file. 

E.g that the German language file will link to: http://www.gnu.org/philosophy/free-sw.de.html and the Arab language file will like to: http://www.gnu.org/philosophy/free-sw.ar.html

Oh and "approval-required" needs a translation, too.

Best regards

Martin aka MenMan
