### PR TITLE
[urgent] Fixed JSON syntax error

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -198,7 +198,7 @@
 
   "i18n-email-services-note": "<p><strong>Riseup</strong> est hébergé aux Etats-Unis, au cas où vous y portez une attention.</p><p>Pourquoi pas Hushmail&nbsp;? Consultez <a href='https://en.wikipedia.org/wiki/Hushmail#Compromises_to_email_privacy'>&laquo;&nbsp;les compromis sur le caractère privée des emails&nbsp;&raquo;</a (en anglais).</p>",
 
-  "i18n-email-clients-note": "<p>Voici <a href="http://www.enigmail.net/documentation/quickstart-ch1.php">un guide</a> pour chiffrer vos courriels avec Thunderbird, GNU Privacy Guard (GPG) et Enigmail.</p>",
+  "i18n-email-clients-note": "<p>Voici <a href=\"http://www.enigmail.net/documentation/quickstart-ch1.php\">un guide</a> pour chiffrer vos courriels avec Thunderbird, GNU Privacy Guard (GPG) et Enigmail.</p>",
 
   "i18n-email-encryption-note": "<p>&laquo;&nbsp;Pretty Good Privacy (PGP)&nbsp;&raquo; est un logiciel de chiffrement et déchiffrement cryptographique qui permet d'authentifier les communications électroniques. PGP est souvent utilisé pour signer et (dé)chiffrer des textes, des e-mails, des fichiers voire d'entières partitions de support de stockage afin d'améliorer la sécurité.&nbsp;&raquo;</p><p>&mdash; <a href='https://fr.wikipedia.org/wiki/Pretty_Good_Privacy'>La Wikipédia</a>",
 


### PR DESCRIPTION
The French version is broken because of a un-escaped quote in fr.json. Here is a fixed version.
