### PR TITLE
Remove remark that Adblock Edge uses less memory than Adblock Plus

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -202,7 +202,7 @@
 
   "i18n-web-browser-note": "<p>Benutze eine Kombination aus dem <strong>Tor Browser</strong> und einem freien Browser Deiner Wahl um im Web zu surfen.</p> <p>Versuche den <strong>Tor Browser</strong> so oft wie möglich zu nutzen. Mit Tor zu surfen ist langsamer, aber deutlich sicherer.</p> <p>Anmerkung: <strong>Mozilla Firefox</strong> ist eigentlich keine vollständig freie Software, da Mozilla unfreie Add-Ons auf ihrer Seite empfiehlt.</p>",
 
-  "i18n-web-browser-addons-note": "<p>Schütze Deine Privatsphäre, in dem Du Adblock Edge, Disconnect, HTTPS Everywhere, und NoScript für Deinen Browser installierst.</p> <p>Warum nicht Adblock Plus?<br>Adblock Plus zeigt &ldquo;unaufdringliche Werbung&rdquo; standardmäßig an und benutzt mehr Speicher als <strong>Adblock Edge</strong>.</p> <p>Warum nicht Ghostery?<br>Ghostery ist ein proprietäres Add-On. Benutze stattdessen <strong>Disconnect</strong>.</p>",
+  "i18n-web-browser-addons-note": "<p>Schütze Deine Privatsphäre, in dem Du Adblock Edge, Disconnect, HTTPS Everywhere, und NoScript für Deinen Browser installierst.</p> <p>Warum nicht Adblock Plus?<br>Adblock Plus zeigt &ldquo;unaufdringliche Werbung&rdquo; standardmäßig an.</p> <p>Warum nicht Ghostery?<br>Ghostery ist ein proprietäres Add-On. Benutze stattdessen <strong>Disconnect</strong>.</p>",
 
   "i18n-web-search-note": "<p><strong>Startpage</strong> ist proprietär, wird in den USA/Niederlanden gehostet und versorgt Dich mit anonymisierten Google-Suchergebnissen (inklusive Bildern).</p><p><strong>DuckDuckGo</strong> ist teilweise proprietär, wird in den USA gehostet und versorgt Dich mit anonymisierten Suchergebnissen von verschiedenen Anbietern.</p><p>Wähle das kleinere Übel.</p>",
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,7 +20,7 @@
   "i18n-disconnect-desc": "Stop third-party sites from tracking you.",
   "i18n-noscript-desc": "Only enable JavaScript, Java, and Flash for sites you trust.",
   "i18n-requestpolicy-desc": "Control which cross-site requests are allowed by sites you visit.",
-  "i18n-web-browser-addons-note": "<p>Safeguard your privacy and stop websites from tracking you by installing Adblock Edge, Disconnect, and HTTPS Everywhere in your browser.</p><p>Why not Adblock Plus? Adblock Plus shows &ldquo;acceptable ads&rdquo; by default, and uses more memory than <strong>Adblock Edge</strong>.</p> <p>Why not Ghostery? Ghostery is a proprietary plugin. Use <strong>Disconnect</strong> instead.</p>",
+  "i18n-web-browser-addons-note": "<p>Safeguard your privacy and stop websites from tracking you by installing Adblock Edge, Disconnect, and HTTPS Everywhere in your browser.</p><p>Why not Adblock Plus? Adblock Plus shows &ldquo;acceptable ads&rdquo; by default.</p> <p>Why not Ghostery? Ghostery is a proprietary plugin. Use <strong>Disconnect</strong> instead.</p>",
 
   "i18n-web-search": "Web search",
   "i18n-duckduckgo-desc": "Anonymous, unlogged web searches.",


### PR DESCRIPTION
It's not true. Ablock Edge is an (apparently unmaintained) fork for an older version of Adblock Plus. Apart from the rebranding, the only change is the removal of the acceptable ads option.

Disclaimer: I work on Adblock Plus. It's totally fine by me if you don't like the idea of acceptable ads and don't want to recommend ABP for that reason. But I'd like to point out that acceptable ads has nothing to do with privacy, EasyList doesn't block most tracking to begin with. You already recommend Disconnect, which takes care of that.
