### PR TITLE
Update de.json

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -81,8 +81,8 @@
   "i18n-gpgmail-desc": "OpenPGP-Add-on für die OS X Mail-App.",
   "i18n-openpgpjs-desc": "OpenPGP-Bibliothek in JavaScript.",
 
-  "i18n-maps": "Atlanten",
-  "i18n-openstreetmap-desc": "Freier, kollaborativer Weltatlas.",
+  "i18n-maps": "Kartendienste",
+  "i18n-openstreetmap-desc": "Freier, kollaborativer Kartendienst.",
 
   "i18n-cloud-storage": "Cloudspeicherung",
   "i18n-gitannex-desc": "Synchronisiert Ordner auf allen Laufwerken Deines Computers.",
@@ -138,7 +138,7 @@
   "i18n-gibberbot-desc": "Privates, sicheres OTR-Messaging für Android.",
   "i18n-orbot-desc": "Tor-Proxy für Android.",
   "i18n-redphone-desc": "Sichere, private Anrufe für Android.",
-  "i18n-surespot-desc": "Freier, quelloffer, End-to-End-verschlüsselter Nachrichtenversand.",
+  "i18n-surespot-desc": "Freier, quelloffer und Ende-zu-Ende-verschlüsselter Nachrichtenversand.",
   "i18n-textsecure-desc": "Sichere SMS-/MMS-Kommunikation für Android.",
   "i18n-xabber-desc": "OTR-verschlüsselter Nachrichtenversand für Android.",
 
@@ -221,7 +221,7 @@
 
   "i18n-email-services-note": "<p><strong>Riseup</strong> wird in den USA gehostet.</p><p>Warum nicht Hushmail?<br>Lese hierzu: <a href=\"https://en.wikipedia.org/wiki/Hushmail#Compromises_to_email_privacy\">&ldquo;Gefährdung Deiner Privatsphäre&rdquo; (engl.)</a>.</p>",
 
-  "i18n-email-clients-note": "<p><a href='http://www.thunderbird-mail.de/wiki/Enigmail#Enigmail_installieren'>Diese</a> und <a href='http://www.spiegel.de/fotostrecke/openpgp-so-verschluesseln-sie-ihre-e-mails-fotostrecke-98718.html'>diese Anleitung</a> helfen Dir, unter Windows Deine Mail mit <strong>Thunderbird</strong>, <strong>GNU Privacy Guard (GnuPG)</strong> und <strong>Enigmail</strong> zu verschlüsseln.</p><p>Anleitungen, wie man GnuPG bzw. GPG unter <a href='http://wiki.ubuntuusers.de/GnuPG'>Ubuntu</a> und <a href='http://www.verbraucher-sicher-online.de/anleitung/e-mails-verschluesseln-in-apple-mail-unter-mac-os-x?page=0,2#eigenes_schluesselpaar'>OS X</a> nutzt, sind auch verfügbar.</p>",
+  "i18n-email-clients-note": "<p><a href='http://www.thunderbird-mail.de/wiki/Enigmail'>Diese</a> und <a href='http://www.spiegel.de/fotostrecke/openpgp-so-verschluesseln-sie-ihre-e-mails-fotostrecke-98718.html'>diese Anleitung</a> helfen Dir, unter Windows Deine Mail mit <strong>Thunderbird</strong>, <strong>GNU Privacy Guard (GnuPG)</strong> und <strong>Enigmail</strong> zu verschlüsseln.</p><p>Anleitungen, wie man GnuPG bzw. GPG unter <a href='http://wiki.ubuntuusers.de/GnuPG'>Ubuntu</a> und <a href='http://www.verbraucher-sicher-online.de/anleitung/e-mails-verschluesseln-in-apple-mail-unter-mac-os-x'>OS X</a> nutzt, sind auch verfügbar.</p>",
 
   "i18n-email-encryption-note": "<p>&ldquo;Pretty Good Privacy (PGP, deutsch sinngemäß „Ziemlich gute Privatsphäre“) ist ein Programm zur Verschlüsselung und zum Unterschreiben von Daten.&rdquo;</p><p>&mdash; <a href=\"https://de.wikipedia.org/wiki/Pretty_Good_Privacy\">Wikipedia</a><br><p>PGP wird häufig zum signieren, verschlüsseln und entschlüsseln von Texten, E-Mails, Dateien, Ordnern und ganzen Festplattenpartitionen genutzt, um die Sicherheit von E-Mailkommunikation zu erhöhen.</p>",
 


### PR DESCRIPTION
fixed the expressions and URLs
- OSM calls itself "Die freie Wiki-Welt_KARTE_". Therefore "_KARTEN_dienst".
- precise URL linking
