### PR TITLE
Remove duplicated HexChat's icon.

### DIFF
--- a/index.html
+++ b/index.html
@@ -991,7 +991,6 @@
                 </p>
             </a></li>
             <li class='hideable'>
-              <a href='http://hexchat.github.io/'><img class='logo' src='lib/img/free/hexchat.png' alt='' />
               <a href='http://www.weechat.org/'><img class='logo' src='lib/img/free/weechat.png' alt='' />
                 <h5>WeeChat</h5>
                 <p class='desc'>


### PR DESCRIPTION
Example of the bug: http://www.korzen.org/s/vidpegVaj5/prism-break-hex-chat-double-icon.png
