### PR TITLE
MyKolab.com now also has email-only pricing, and payment period discounts

### DIFF
--- a/index.html
+++ b/index.html
@@ -666,7 +666,7 @@
               <a href='https://MyKolab.com'><img class='logo' src='lib/img/free/mykolabcom.png' alt='' />
                 <h5>MyKolab</h5>
                 <p class='desc'>
-                  <span class='i18n-mykolabcom-desc'>Secure, private Kolab accounts hosted in Switzerland for 10 CHF per month.</span>
+                  <span class='i18n-mykolabcom-desc'>Secure, private Kolab accounts hosted in Switzerland. Email from 4.85 CHF, full groupware from 9.70 CHF per month.</span>
                   <span class='fs i18n-paid-service'>paid service</span>
                 </p>
             </a></li>


### PR DESCRIPTION
The pricing for MyKolab.com was no longer correct because we now have the long-requested email-only accounts.

Also we provide some payment term discounts.
