### PR TITLE
Added several Safari extensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,8 +455,15 @@
                   <span class='i18n-adblockedge-desc'>Block advertisements and trackers across the web with filter subscriptions.</span>
                 </p>
             </a></li>
+            <li class="hidable">
+              <a href='http://safariadblock.com'><img class='logo' src='' alt='' />
+                <h5>Safari Adblock</h5>
+                <p class='desc'>
+                  <span class='i18n-adblockedge-desc'>Block advertisements and trackers across the web with filter subscriptions. This version is for Safari.</span>
+                </p>
+            </a></li>
             <li>
-              <a href='https://disconnect.me/'><img class='logo' src='lib/img/free/disconnect.png' alt='' />
+ad              <a href='https://disconnect.me/'><img class='logo' src='lib/img/free/disconnect.png' alt='' />
                 <h5>Disconnect</h5>
                 <p class='desc'>
                   <span class='i18n-disconnect-desc'>Visualize and block invisible tracking of your search and browsing history.</span>
@@ -474,6 +481,22 @@
                 <h5>NoScript</h5>
                 <p class='desc'>
                   <span class='i18n-noscript-desc'>Only enable JavaScript, Java, and Flash for sites you trust.</span>
+                  <span class='fs i18n-advanced'>advanced</span>
+                </p>
+            </a></li>
+            <li class="hideable">
+              <a href='http://javascript-blocker.toggleable.com'><img class='logo' src='' alt='' />
+                <h5>JavaScript Blocker</h5>
+                <p class='desc'>
+                  <span class='i18n-javascriptblocker-desc'>Similar to NoScript, but runs in Safari (Windows and Mac). Only enable JavaScript, Java, and Flash for sites you trust.</span>
+                  <span class='fs i18n-advanced'>advanced</span>
+                </p>
+            </a></li>
+            <li class="hideable">
+              <a href='https://extensions.apple.com'><img class='logo' src='' alt='' />
+                <h5>DuckDuckGo for Safari</h5>
+                <p class='desc'>
+                  <span class='i18n-duckduckgosafari-desc'>A Safari extension that redirects the default search in the addressbar to DuckDuckGo instead of the three less-secure options provided in Safari's preferences.</span>
                   <span class='fs i18n-advanced'>advanced</span>
                 </p>
             </a></li>


### PR DESCRIPTION
Added "JavaScriptBlocker," "Adblock" and "DuckDuckGo for Safari." All extensions added as "hideable" class list items due to generally untrustworthy nature of Safari and OS X. Icons not yet uploaded to lib/img; need to check copyrights.
