### PR TITLE
Fixing link for Exim

### DIFF
--- a/index.html
+++ b/index.html
@@ -2075,7 +2075,7 @@
                 </p>
             </a></li>
             <li><span class='h4 i18n-mail-transfer-agent'>Mail transfer agent (MTA)</span></li>
-            <li><a href='http://indimail.sourceforge.net/'>
+            <li><a href='hhttp://www.exim.org/'>
                 <img class='logo' src='lib/img/free/exim.png' alt='' />
                 <h5>Exim</h5>
                 <p class='desc'>


### PR DESCRIPTION
On your website, the link which should point to Exim points to Indimail. I fixed the link for Exim (despite the fact that my personal mail server runs Postfix).
