### PR TITLE
Fix Exim link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2075,7 +2075,7 @@
                 </p>
             </a></li>
             <li><span class='h4 i18n-mail-transfer-agent'>Mail transfer agent (MTA)</span></li>
-            <li><a href='hhttp://www.exim.org/'>
+            <li><a href='http://www.exim.org/'>
                 <img class='logo' src='lib/img/free/exim.png' alt='' />
                 <h5>Exim</h5>
                 <p class='desc'>


### PR DESCRIPTION
When I submitted the fixed Exim link, I accidentally put hhttp instead http. I fixed this problem.
Sorry if I have to bother you again. I'm just contributing to the website.
