### PR TITLE
update ChatSecure for iOS with XMPP tag too

### DIFF
--- a/index.html
+++ b/index.html
@@ -1076,6 +1076,7 @@
                 <h5>ChatSecure</h5>
                 <p class='desc'>
                   <span class='i18n-chatsecure-desc'>Encrypted IM for iOS devices.</span>
+                  <span class='fs'>XMPP</span>
                   <span class='fs'>OTR</span>
                 </p>
             </a></li>


### PR DESCRIPTION
Like mentioned in #763 ChatSecure is an XMPP client. I accidentally forgot to update the iOS version too.
