### PR TITLE
Edit descriptions for several sites

### DIFF
--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -125,7 +125,7 @@
     "slug": "arch-linux"
   },
   {
-    "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
+    "description": "Lightweight self-hosting for websites, email, files, and more on Raspberry Pi",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",
     "notes": "",
@@ -369,7 +369,7 @@
     "slug": "buddycloud"
   },
   {
-    "description": "Byzantium is a live Linux distribution that delivers easy-to-use mesh networking.",
+    "description": "Live Linux distribution that delivers easy-to-use mesh networking.",
     "license_url": "https://github.com/Byzantium/Byzantium/blob/master/LICENSE",
     "logo": "byzantium.png",
     "notes": "",
@@ -421,7 +421,7 @@
     "slug": "byzantium"
   },
   {
-    "description": "Enterprise class computing platform with 100% binary compatbility with RHEL.",
+    "description": "REHL-compatible enterprise computing platform.",
     "license_url": "http://mirror.centos.org/centos/6/os/x86_64/GPL",
     "logo": "centos.png",
     "notes": "",
@@ -474,7 +474,7 @@
     "slug": "chatsecure"
   },
   {
-    "description": "Cjdns is a networking protocol, a system of digital rules for message exchange between computers. \"Instead of letting other computers connect to you through a shared IP address which anyone can use, cjdns only lets computers talk to one other after they have verified each other cryptographically. ",
+    "description": "A networking protocol, a system of digital rules for message exchange between computers. \"Instead of letting other computers connect to you through a shared IP address which anyone can use, cjdns only lets computers talk to one other after they have verified each other cryptographically.",
     "license_url": "https://github.com/cjdelisle/cjdns/blob/master/LICENSE",
     "logo": "cjdns.png",
     "notes": "",
@@ -564,7 +564,7 @@
     "slug": "claws-mail"
   },
   {
-    "description": "DNS hosting service with DNSCrypt, DNSSec, and Namecoin support.",
+    "description": "DNS hosting with DNSCrypt, DNSSec, and Namecoin support.",
     "license_url": "",
     "logo": "cloudns.png",
     "notes": "",
@@ -660,7 +660,7 @@
     "slug": "cozy"
   },
   {
-    "description": "Private and encrypted instant messaging within the web browser.",
+    "description": "Encrypted instant messaging within your web browser.",
     "license_url": "https://github.com/cryptocat/cryptocat/blob/master/LICENSE.txt",
     "logo": "cryptocat.png",
     "notes": "",
@@ -712,7 +712,7 @@
     "slug": "cryptocat"
   },
   {
-    "description": "LUKS is a convenience and ease-of-use layer for use on top of dm-crypt.",
+    "description": "A convenience and ease-of-use layer for use on top of dm-crypt.",
     "license_url": "https://code.google.com/p/cryptsetup/source/browse/COPYING",
     "logo": "luks.png",
     "notes": "Gentoo maintains [a guide](https://wiki.gentoo.org/wiki/DM-Crypt_LUKS) for dm-crypt with LUKS.\n\nArch Linux also maintains [a guide](https://wiki.archlinux.org/index.php/Dm-crypt_with_LUKS) to dm-crypt with LUKS.\n\ndm-crypt is available for DragonFly BSD.",
@@ -991,7 +991,7 @@
     "slug": "diskcryptor"
   },
   {
-    "description": "A tool to secure communications between a client and a DNS resolver.",
+    "description": "Secure communications between a client and a DNS resolver.",
     "license_url": "https://github.com/jedisct1/dnscrypt-proxy/blob/master/COPYING",
     "logo": "dnscrypt.png",
     "notes": "",
@@ -1013,7 +1013,7 @@
     "slug": "dnscrypt"
   },
   {
-    "description": "DragonFly BSD is a free Unix-like operating system created as a fork of FreeBSD 4.8. Matthew Dillon, an Amiga developer in the late 1980s and early 1990s and a FreeBSD developer between 1994 and 2003, began work on DragonFly BSD in June 2003 and announced it on the FreeBSD mailing lists on 16 July 2003.",
+    "description": "Free Unix-like operating system created as a fork of FreeBSD 4.8. Matthew Dillon, an Amiga developer in the late 1980s and early 1990s and a FreeBSD developer between 1994 and 2003, began work on DragonFly BSD in June 2003 and announced it on the FreeBSD mailing lists on 16 July 2003.",
     "license_url": "https://www.dragonflybsd.org/docs/developer/DragonFly_BSD_License/",
     "logo": "dragonfly-bsd.png",
     "notes": "",
@@ -1078,7 +1078,7 @@
     "slug": "duckduckgo"
   },
   {
-    "description": "A free securely-hosted online poll with an optional privacy-enhanced version.",
+    "description": "A free online poll with an optional privacy-enhanced version.",
     "license_url": "https://dudle.inf.tu-dresden.de/about.cgi",
     "logo": "dudle.png",
     "notes": "",
@@ -1373,7 +1373,7 @@
     "slug": "exim"
   },
   {
-    "description": "Free and open source alternative to the Google Play app store for Android.",
+    "description": "Alternative to the Google Play app store for Android.",
     "license_url": "https://f-droid.org/about/",
     "logo": "f-droid.png",
     "notes": "",
@@ -1429,7 +1429,7 @@
     "slug": "fedora"
   },
   {
-    "description": "Free and open source operating system for Android-compatible devices.",
+    "description": "Open source operating system for Android-compatible devices.",
     "license_url": "https://www.mozilla.org/en-US/foundation/licensing/",
     "logo": "mozilla-firefox.png",
     "notes": "",
@@ -1497,7 +1497,7 @@
     "slug": "freebsd"
   },
   {
-    "description": "FreedomBox integrates privacy protection on a cheap plug server so everybody can have privacy.",
+    "description": "Privacy protection on a cheap plug server so everybody can have privacy.",
     "license_url": "http://anonscm.debian.org/gitweb/?p=freedombox/freedom-maker.git;a=blob;f=COPYING;h=94a9ed024d3859793618152ea559a168bbcbb5e2;hb=HEAD",
     "logo": "freedombox.png",
     "notes": "",
@@ -1617,7 +1617,7 @@
     "slug": "freifunk"
   },
   {
-    "description": "Privacy respecting, distributed, federated social network.",
+    "description": "Distributed, federated social network.",
     "license_url": "https://github.com/friendica/friendica/blob/master/LICENSE",
     "logo": "friendica.png",
     "notes": "",
@@ -1934,7 +1934,7 @@
     "slug": "gnunet"
   },
   {
-    "description": "A port of the whole GnuPG 2.1 suite to Android.\n\nGnu Privacy Guard (GPG) gives you access to the entire GnuPG suite of encryption software. GnuPG is GNU’s tool for end-to-end secure communication and encrypted data storage. This trusted protocol is the free software alternative to PGP. GnuPG 2.1 is the new modularized version of GnuPG that now supports OpenPGP and S/MIME.",
+    "description": "A port of GnuPG 2.1 to Android.\n\nGnu Privacy Guard (GPG) gives you access to the entire GnuPG suite of encryption software. GnuPG is GNU’s tool for end-to-end secure communication and encrypted data storage. This trusted protocol is the free software alternative to PGP. GnuPG 2.1 is the new modularized version of GnuPG that now supports OpenPGP and S/MIME.",
     "license_url": "https://github.com/guardianproject/gnupg-for-android/blob/master/LICENSE.txt",
     "logo": "gnupg-for-android.png",
     "notes": "",
@@ -1959,7 +1959,7 @@
     "slug": "gpg-for-android"
   },
   {
-    "description": "Gpg4win is an installation package for Windows (XP, Vista, 7 and 8) with software tools and manuals for email and file encryption on behalf of the German Information Security Agency. Gpg4win itself and all tools of Gpg4win are free and open source software. The software mainly uses public-key cryptography for data encryption and digital signatures.",
+    "description": "Email and file encryption for Windows (XP, Vista, 7 and 8) behalf of the German Information Security Agency. Gpg4win itself and all tools of Gpg4win are free and open source software. The software mainly uses public-key cryptography for data encryption and digital signatures.",
     "license_url": "http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpg4win.git;a=blob;f=COPYING;h=623b6258a134210f0b0ada106fdaab7f0370d9c5;hb=HEAD",
     "logo": "gpg4win.png",
     "notes": "",
@@ -2161,7 +2161,7 @@
     "slug": "i2p"
   },
   {
-    "description": "Image hosting with in-browser AES-256 encryption.",
+    "description": "Client-side encrypted image hosting",
     "license_url": "https://github.com/imgbi/img.bi/blob/master/LICENSE",
     "logo": "imgbi.png",
     "notes": "The img.bi service is also available on Tor: [http://imgbifwwqoixh7te.onion/](http://imgbifwwqoixh7te.onion/).\n\nAnd I2P as an [eepsite](http://imgbi.i2p/?i2paddresshelper=HlMhQ2p~WB9WiehsAa2IDfndqXTMTOeYfOIxpeQH5hSeXLxtwUhd9FsaYmXM-hq66jRREcTpBqNmbILwQsInuBnQ7PZTgLel4tdKMrKhUlxDout4eZ6uRRN6QMWX9YzDCV0cmLBWHRcZlFaBirs3RbF5neUXgdnNqgcvdanQEt5-XN05I5JrIe~Dld9vQ1Z0WSn10BcOtXDm7uxnaHqJUbhtfOgmFoGAxF~di220GpRCzDP6Eg9NRIwAGGFxH8Y7PEOmlqiUCOn5aHwxk2msqrFLzBy6aVWq-e8etrhDxckPvJby7G13QCmVCO-cOOYOObP6bk51t99t5DNxIsGEuoEaUHyVNqAf9jvMjAcqpt6Gdk8slcV528rnSXJ6Vu2gcYYnb~kmt7wtvgm46xTE0OXxdDAmbtsRu~U6oSxRROkw02Q7hdnMmiF86dTYxx-dQ6H8aPQJV1SM5cNlv3XfqBl-V0-TounGNPcj4279s4DUs7-FfhuKYJjbZj5KOlPNAAAA)",
@@ -2237,7 +2237,7 @@
     "slug": "iredmail"
   },
   {
-    "description": "Ixquick is a metasearch engine based in New York and the Netherlands. ",
+    "description": "Metasearch engine based in New York and the Netherlands. ",
     "license_url": "",
     "logo": "ixquick.png",
     "notes": "",
@@ -2716,7 +2716,7 @@
     "slug": "linux-mint-debian"
   },
   {
-    "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
+    "description": "Peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
     "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
@@ -2878,7 +2878,7 @@
     "slug": "marble"
   },
   {
-    "description": "Privacy-first fast media (image, audio, video) hosting",
+    "description": "Fast image, audio, and video hosting",
     "license_url": "https://github.com/MediaCrush/MediaCrush/blob/master/LICENSE",
     "logo": "mediacrush.png",
     "notes": "Warning: MediaCrush includes Google Analytics if you do not enable Do Not Track.",
@@ -3226,7 +3226,7 @@
     "slug": "namecoin"
   },
   {
-    "description": "NetBSD is an open-source Unix-like operating system descended from Berkeley Software Distribution (BSD), a Unix derivative developed at the University of California, Berkeley. It was the second open-source BSD descendant to be formally released, after 386BSD, and it continues to be actively developed. The NetBSD project is primarily focused on high-quality design, stability and performance of the system. ",
+    "description": "Unix-like operating system descended from Berkeley Software Distribution (BSD), a Unix derivative developed at the University of California, Berkeley. It was the second open-source BSD descendant to be formally released, after 386BSD, and it continues to be actively developed. The NetBSD project is primarily focused on high-quality design, stability and performance of the system. ",
     "license_url": "https://www.netbsd.org/about/redistribution.html",
     "logo": "netbsd.png",
     "notes": "",
@@ -3427,7 +3427,7 @@
     "slug": "onion-browser"
   },
   {
-    "description": "The Open Source Routing Machine or OSRM is a C++ implementation of a high-performance routing engine for shortest paths in road networks. Licensed under the permissive 2-clause BSD license, OSRM is a free network service. OSRM supports Linux, FreeBSD, Windows, and Mac platform.",
+    "description": "C++ implementation of a high-performance routing engine for shortest paths in road networks. Licensed under the permissive 2-clause BSD license, OSRM is a free network service. OSRM supports Linux, FreeBSD, Windows, and Mac platform.",
     "license_url": "https://github.com/DennisOSRM/Project-OSRM/blob/master/LICENCE.TXT",
     "logo": "osrm.png",
     "notes": "OSRM should be installed and run locally on your PC to avoid potential data leaks from the unencrypted online service.",
@@ -3575,7 +3575,7 @@
     "slug": "opennic"
   },
   {
-    "description": "OpenPGP Keychain is an OpenPGP implementation for Android.",
+    "description": "OpenPGP implementation for Android.",
     "license_url": "https://github.com/dschuermann/openpgp-keychain/blob/master/LICENSE",
     "logo": "openpgp-keychain.png",
     "notes": "OpenPGP Keychain is EXPERIMENTAL software. Use at your own risk!\r",
@@ -3767,7 +3767,7 @@
     "slug": "orbot"
   },
   {
-    "description": "OsmAnd (OSM Automated Navigation Directions) is a map and navigation app that uses OpenStreetMap data.",
+    "description": "Map and navigation app that uses OpenStreetMap data.",
     "license_url": "https://github.com/osmandapp/Osmand/blob/master/LICENSE",
     "logo": "osmand.png",
     "notes": "",
@@ -4329,7 +4329,7 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "Scientific Linux (SL) is a Linux distribution produced by Fermi National Accelerator Laboratory and the European Organization for Nuclear Research (CERN). ",
+    "description": "Linux distribution produced by Fermi National Accelerator Laboratory and the European Organization for Nuclear Research (CERN). ",
     "license_url": "https://www.scientificlinux.org/documentation/faq/legal",
     "logo": "scientific-linux.png",
     "notes": "",
@@ -4765,7 +4765,7 @@
     "slug": "tinc"
   },
   {
-    "description": "Tor (previously TOR, an acronym for The Onion Router)[not in citation given] is free software for enabling online anonymity. Tor directs Internet traffic through a free, worldwide, volunteer network consisting of more than four thousand relays to conceal a user's location or usage from anyone conducting network surveillance or traffic analysis. Using Tor makes it more difficult to trace Internet activity, including \"visits to Web sites, online posts, instant messages, and other communication forms\", back to the user and is intended to protect the personal privacy of users, as well as their freedom and ability to conduct confidential business by keeping their internet activities from being monitored.",
+    "description": "Free software for enabling online anonymity. Tor directs Internet traffic through a free, worldwide, volunteer network consisting of more than four thousand relays to conceal a user's location or usage from anyone conducting network surveillance or traffic analysis. Using Tor makes it more difficult to trace Internet activity, including \"visits to Web sites, online posts, instant messages, and other communication forms\", back to the user and is intended to protect the personal privacy of users, as well as their freedom and ability to conduct confidential business by keeping their internet activities from being monitored.",
     "license_url": "https://gitweb.torproject.org/tor.git/blob/HEAD:/LICENSE",
     "logo": "tor.png",
     "notes": "",


### PR DESCRIPTION
While working on #815, I noticed that the site redesign made it harder to evaluate the choices you're offered. See this:

![2014-01-10_11 48 29](https://f.cloud.github.com/assets/1310872/1890923/f81eec8c-7a33-11e3-9510-00bd543a6ec4.png)

What's the difference between these three services? It's harder to tell now. I made some edits to a lot of these services to remove redundant information (the name of each service is already shown above it, and I assumed that things like "private" and "open source" and "secure" were implied as a result of their inclusion on the site). The goal was to move as much info _before_ the ellipsis as possible.

After:

![2014-01-10_12 15 08](https://f.cloud.github.com/assets/1310872/1890924/fb8557a8-7a33-11e3-8997-8fc8fed2d8dc.png)

For the record, I made edits to a lot of descriptions, not just the ones pictured.
