### PR TITLE
Change url and description for ChatSecure

### DIFF
--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -437,15 +437,15 @@
     "slug": "centos"
   },
   {
-    "description": "Encrypted IM for iOS.",
-    "license_url": "https://github.com/guardianproject/ChatSecureAndroid/blob/master/LICENSE",
+    "description": "OTR-encrypted IM for Android and iOS.",
+    "license_url": "https://chatsecure.org/developers/",
     "logo": "chatsecure.png",
     "notes": "The Guardian Project hosts <a href='https://guardianproject.info/howto/chatsecurely/'>a fantastic how-to guide</a> to chatting securely on Android.",
     "privacy_url": "",
-    "source_url": "https://github.com/guardianproject/ChatSecureAndroid",
+    "source_url": "https://chatsecure.org/developers/",
     "name": "ChatSecure",
     "tos_url": "",
-    "url": "https://guardianproject.info/apps/chatsecure/",
+    "url": "https://chatsecure.org/",
     "wikipedia_url": "",
     "protocols": [
       "OTR",


### PR DESCRIPTION
ChatSecure is for Android and iOS, and their respective license and URL source-code are differents.
