### PR TITLE
Make “Source Code” string translatable.

### DIFF
--- a/source/views/projects/mixins.jade
+++ b/source/views/projects/mixins.jade
@@ -99,7 +99,7 @@ mixin project-tail(project)
       mixin filler-bars(project.protocolsSlugged)
 
   .section
-    .pipe= ['Source Code']
+    .pipe= t['Source Code']
 
     - if(project.license_url !== '')
       a.bar(href=project.license_url)


### PR DESCRIPTION
Fixing #861, I think.
