### PR TITLE
Remove references from RSS and Tor descriptions.

### DIFF
--- a/source/db/en-protocols.js
+++ b/source/db/en-protocols.js
@@ -93,7 +93,7 @@
     }, {
       name: "Tor",
       full_name: "The Onion Router",
-      description: "Tor (previously TOR, an acronym for The Onion Router)[5] is a free software for enabling online anonymity. Tor directs Internet traffic through a free, worldwide, volunteer network consisting of more than four thousand relays[6] to conceal a user's location or usage from anyone conducting network surveillance or traffic analysis. Using Tor makes it more difficult to trace Internet activity, including \"visits to Web sites, online posts, instant messages, and other communication forms\", back to the user[7] and is intended to protect the personal privacy of users, as well as their freedom and ability to conduct confidential business by keeping their internet activities from being monitored.",
+      description: "Tor (previously TOR, an acronym for The Onion Router) is a free software for enabling online anonymity. Tor directs Internet traffic through a free, worldwide, volunteer network consisting of more than four thousand relays to conceal a user's location or usage from anyone conducting network surveillance or traffic analysis. Using Tor makes it more difficult to trace Internet activity, including \"visits to Web sites, online posts, instant messages, and other communication forms\", back to the user and is intended to protect the personal privacy of users, as well as their freedom and ability to conduct confidential business by keeping their internet activities from being monitored.",
       wikipedia_url: "https://en.wikipedia.org/wiki/Tor_%28anonymity_network%29",
       categories: [{
         name: "Anonymity"

--- a/source/db/en-protocols.ls
+++ b/source/db/en-protocols.ls
@@ -90,7 +90,7 @@ protocols =
 
   * name: "Tor"
     full_name: "The Onion Router"
-    description: "Tor (previously TOR, an acronym for The Onion Router)[5] is a free software for enabling online anonymity. Tor directs Internet traffic through a free, worldwide, volunteer network consisting of more than four thousand relays[6] to conceal a user's location or usage from anyone conducting network surveillance or traffic analysis. Using Tor makes it more difficult to trace Internet activity, including \"visits to Web sites, online posts, instant messages, and other communication forms\", back to the user[7] and is intended to protect the personal privacy of users, as well as their freedom and ability to conduct confidential business by keeping their internet activities from being monitored."
+    description: "Tor (previously TOR, an acronym for The Onion Router) is a free software for enabling online anonymity. Tor directs Internet traffic through a free, worldwide, volunteer network consisting of more than four thousand relays to conceal a user's location or usage from anyone conducting network surveillance or traffic analysis. Using Tor makes it more difficult to trace Internet activity, including \"visits to Web sites, online posts, instant messages, and other communication forms\", back to the user and is intended to protect the personal privacy of users, as well as their freedom and ability to conduct confidential business by keeping their internet activities from being monitored."
     wikipedia_url: "https://en.wikipedia.org/wiki/Tor_%28anonymity_network%29"
     categories: [
       * name: "Anonymity"


### PR DESCRIPTION
Reference numbers from Wikipedia were still visible in these descriptions.

Fixes #909.
