### PR TITLE
Update eo-projects.json

### DIFF
--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -1022,7 +1022,7 @@
     "name": "DragonFly BSD",
     "tos_url": "",
     "url": "https://www.dragonflybsd.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/PC-BSD",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/DragonFly_BSD",
     "protocols": [],
     "categories": [
       {


### PR DESCRIPTION
updated the wikipedia link to https://en.wikipedia.org/wiki/DragonFly_BSD.  It was https://en.wikipedia.org/wiki/PC-BSD
