### PR TITLE
Fixed spelling in en-projects.json

### DIFF
--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -415,7 +415,7 @@
     "slug": "byzantium"
   },
   {
-    "description": "REHL-compatible enterprise computing platform.",
+    "description": "RHEL-compatible enterprise computing platform.",
     "license_url": "http://mirror.centos.org/centos/6/os/x86_64/GPL",
     "logo": "centos.png",
     "notes": "",


### PR DESCRIPTION
from 'REHL' to 'RHEL'
