### PR TITLE
add the ownCloud desktop and mobile clients

### DIFF
--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -3782,7 +3782,7 @@
     "description": "Cloud data in your control.",
     "license_url": "https://github.com/owncloud/core/blob/master/COPYING-README",
     "logo": "owncloud.png",
-    "notes": "",
+    "notes": "ownCloud provides a file sync and share solution that respects your privacy. Sync clients are available for all major platforms. ownCloud comes with a rich ecosystem of apps, which makes it possible to manage contacts, appointments, music and much more.",
     "privacy_url": "",
     "source_url": "https://github.com/owncloud",
     "name": "ownCloud",
@@ -3792,11 +3792,42 @@
     "protocols": [
       "CalDAV",
       "CardDAV",
+      "WebDAV",
       "RSS"
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Web Services",
         "subcategories": [
           "File Storage & Sync"
         ]


### PR DESCRIPTION
Like discussed here https://github.com/nylira/prism-break/issues/973 I added the categories gnu/linux, bsd, windows, osx and android to the ownCloud description to reflect the fact that ownCloud offers Free Software sync clients for all these platforms.
