### PR TITLE
Update OpenKeychain note and fix link

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain ist eine OpenPGP-Implementierung für Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain ist EXPERIMENTELLE software. Benutzung auf eigene Gefahr!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain &egrave; un&#39;implementazione OpenPGP per Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain &egrave; un software SPERIMENTALE. Usare a proprio rischio!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -4007,12 +4007,12 @@
     "description": "Реализация OpenPGP для Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain — ЭКСПЕРИМЕНТАЛЬНОЕ программное обеспечение. Используйте его на свой страх и риск!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain是安卓平台上的OpenPGP实现。",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -4007,12 +4007,12 @@
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",
-    "notes": "OpenKeychain is EXPERIMENTAL software. Use at your own risk!\r",
+    "notes": "",
     "privacy_url": "",
     "source_url": "https://github.com/open-keychain/open-keychain",
     "name": "OpenKeychain",
     "tos_url": "",
-    "url": "http://www.open-keychain.org/",
+    "url": "http://www.openkeychain.org/",
     "wikipedia_url": "",
     "protocols": [
       "GPG"


### PR DESCRIPTION
Hi maintainer of OpenKeychain here.
OpenKeychain is no longer experimental and actually the recommended PGP app by K-9 Mail.
I removed the note and fixed the link.

I also added https://github.com/nylira/prism-break/issues/1156 for consideration.
