### PR TITLE
fixed couple broken links

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "https://fr.wikipedia.org/wiki/GitLab_CE",
     "protocols": [],
     "categories": [

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://ru.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -5714,7 +5714,7 @@
     "source_url": "https://github.com/gitlabhq/gitlabhq",
     "name": "GitLab",
     "tos_url": "",
-    "url": "http://www.gitlab.org",
+    "url": "https://about.gitlab.com/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -821,7 +821,7 @@
     "source_url": "https://code.google.com/p/cryptsetup/source/browse/",
     "name": "cryptsetup",
     "tos_url": "",
-    "url": "http://code.google.com/p/cryptsetup/",
+    "url": "https://gitlab.com/cryptsetup/cryptsetup",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Dm-crypt",
     "protocols": [],
     "categories": [
@@ -1303,7 +1303,7 @@
     "source_url": "https://code.google.com/p/encfs/source/browse/#svn%2Ftrunk",
     "name": "encfs",
     "tos_url": "",
-    "url": "http://www.arg0.net/encfs",
+    "url": "https://vgough.github.io/encfs/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/EncFS",
     "protocols": [],
     "categories": [


### PR DESCRIPTION
Hello again,

Cryptsetup moved their development to gitlab, and the link pointing to **encfs** was broken.

Cheers