### PR TITLE
Add license url to ProtectedText

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Verschlüsselte Notizen online abspeichern.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText ver- und entschlüsselt Text im Browser, sodass das Passwort (bzw. dessen Hash) nie zum Server gesendet wird.",
     "privacy_url": "",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Vapaa ja salattu online-muistio.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText salaa ja purkaa tekstin selaimessa ja on samalla Zero-Knowledge: Salasanaa (tai sen tiivistettä) ei koskaan lähetetä palvelimelle, eli palveluntarjoa ei viranomaisen määräyksestä pysty luovuttamaan sisältöä.",
     "privacy_url": "",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Bloc-notes gratuit chiffré en ligne.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Blocco note online libero e criptato.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText cifra/decifra i testi nel browser, mentre la password (o il suo hash) non &egrave; mai inviata al server - quindi i testi non possono essere decifrati anche se venisse richiesto dalle autorit&agrave;.",
     "privacy_url": "",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Свободный онлайн блокнот с шифрованием.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText шифрует/расшифровывает текст в браузере, и пароль (или его хеш) никогда не отправляется на сервер, так что текст не может быть расшифрован, даже если этого потребуют власти.",
     "privacy_url": "",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -4449,7 +4449,7 @@
   {
     "development_stage": "released",
     "description": "Free online encrypted notepad.",
-    "license_url": "",
+    "license_url": "https://www.protectedtext.com/js/main.js",
     "logo": "protextedtext.png",
     "notes": "ProtectedText encrypts/decrypts text in the browser, and password (or it's hash) is never sent to the server - so that text can't be decrypted even if requested by authorities.",
     "privacy_url": "",


### PR DESCRIPTION
Closes #1010.

---

@Zegnat So just have the same url as the source code, because the license seems to be an embedded comment in the source code anyway?