### PR TITLE
Fix some broken media links with archive.org backups

### DIFF
--- a/source/views/about/media.jade
+++ b/source/views/about/media.jade
@@ -227,7 +227,7 @@ block content
       span.date 2013-07-05.
     div
       span.author Neagle, Colin.
-      a.title(href='https://www.networkworld.com/community/blog/how-opt-out-prism-nsas-spying-program')
+      a.title(href='https://web.archive.org/web/20140113142442/http://www.networkworld.com/community/blog/how-opt-out-prism-nsas-spying-program')
         | &ldquo;How to opt out of PRISM, the NSA’s spying program.&rdquo;
       span.website Network World.
       span.date 2013-06-10.
@@ -290,7 +290,7 @@ block content
       span.date 2013-06-17.
     div
       span.author Camacho, Victor.
-      a.title(href='http://www.blogarizate.com/2013/07/guia-practica-para-evitar-ser-espiados.html')
+      a.title(href='https://web.archive.org/web/20130811034005/http://www.blogarizate.com/2013/07/guia-practica-para-evitar-ser-espiados.html')
         | &ldquo;Guía práctica para evitar ser espiados en internet.&rdquo;
       span.website Blogarizate.
       span.date 2013-07-28.


### PR DESCRIPTION
Ref #1260.

---

I wouldn't say it "closes" #1260 because there are still these broken links which do not seem to have archive.org backups (they either were not indexed or the snapshots themselves were all broken too):

- Röll, Nadja. http://www.srf.ch/k.text-blocktur/im-fokus/weblese/surfen-ohne-dass-die-nsa-zuschaut
- Luckerson, Victor. http://business.time.com/2013/06/20/the-anonymous-internet-privacy-tools-grow-in-pop.text-blockarity-following-nsa-revelations/
- Informare per resistere. http://www.informarexresistere.fr/2013/07/08/blocca-il-controllo-del-governo-usa-s.text-blockle-tue-attivita-online-liberati-da-prism/

Additionally, this one seems to be behind a paywall (and same with the archive.org versions), which I'm not sure is a problem but might be:

- de Sá, Nelson. http://www1.folha.uol.com.br/colunas/nelsondesa/2013/07/1311846-para-se-livrar-do-google.shtml

But what can you do other than remove them right? So I'll let you decide if this completely solves #1260 or not.