### PR TITLE
Fix uBlock link in source/db/ru-projects.json

### DIFF
--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -6190,14 +6190,14 @@
   {
     "development_stage": "released",
     "description": "An efficient blocker add-on for Firefox and Chromium. Fast, potent, and lean.",
-    "license_url": "https://github.com/gorhill/uBlock/blob/master/LICENSE.txt",
+    "license_url": "https://github.com/chrisaljoudi/uBlock/blob/master/LICENSE.txt",
     "logo": "ublock.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "https://github.com/gorhill/uBlock",
+    "source_url": "https://github.com/chrisaljoudi/uBlock/",
     "name": "uBlock",
     "tos_url": "",
-    "url": "https://github.com/gorhill/uBlock#installation",
+    "url": "https://chrismatic.io/ublock/",
     "wikipedia_url": "",
     "protocols": [],
     "categories": [


### PR DESCRIPTION
I think this might be a mistake somehow because none of the other language files have gorhill's one? This may eventually be changed back (due to #1291) anyway, but for now I think fixing it would reduce/stop any possible confusion.