### PR TITLE
Fix sidebar being too long for GNU/Linux and Windows categories

### DIFF
--- a/source/stylesheets/screen.styl
+++ b/source/stylesheets/screen.styl
@@ -22,7 +22,7 @@
     position absolute
 
 // solves fixed sidebar (category show) being too long
-@media (max-height: 720px)
+@media (max-height: 755px)
   body.categories.show #container .content-side
     position absolute
 


### PR DESCRIPTION
With a browser height at 724 px (basically fullscreen browser on a 1366x768 res screen minus some panels), I just miss out on the fix. I know this is probably arbitrary and depends on users fonts or something, but 755px seems to be the margin for me where I can I see all categories, so I'm hoping that's acceptable. At 724 px, Web Search and World Maps are cut off (although I can still some of the top of Web Search) on GNU/Linux and Windows. (Obviously the other categories are not long enough.)

This is probably due to the addition of the Bookmark Sync category.