### PR TITLE
Add notice about Bookie.io shutting down

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -439,7 +439,7 @@
     "description": "Bookie is an open source bookmarking application.",
     "license_url": "https://github.com/bookieio/Bookie/blob/develop/COPYING",
     "logo": "bookie.png",
-    "notes": "",
+    "notes": "Bookie.io the hosted site will be <strong>shutting down July 5th</strong>. However, the application can still be self-hosted. See <a href='https://twitter.com/BookieBmarks/status/606388573852430337'>their tweet</a> for more details.",
     "privacy_url": "",
     "source_url": "https://github.com/bookieio/Bookie",
     "name": "Bookie",


### PR DESCRIPTION
Ref #1349.

---

At least for now, until someone decides what to actually do in #1349, because July 5th is not far away.