### PR TITLE
give experimental tag to arkOS

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS ist ein schlanker Software-Stack für den Raspberry Pi, auf dem Du Deine Websites, E-Mails, Daten, etc. sicher selbst hosten kannst.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Lightweight self-hosting for websites, email, files, and more on Raspberry Pi",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS es un conjunto ligero de software para Raspberry Pi útil para auto-hospedar de forma segura tus sitios web, correo electrónico, archivos y más.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS on kevyt ohjelmistopino Raspberry Pi:lle, jonka avulla voit ylläpitää itse verkkosivuja, sähköpostipalvelinta ja paljon muuta.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS est un ensemble de logiciels légers faits pour un Raspberry Pi qui permet d'auto-heberger, de manière sécurisée, son site web, ses emails, ses fichiers, etc.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS היא חבילת תוכנות קלה שרצה על Raspberry Pi בכדי לאחסן בבטחון את האתרים, האי-מייל, הקבצים והדברים האחרים שלך",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS &egrave; un sistema operativo leggero per Raspberry Pi per ospitare in modo sicuro i tuoi siti, email, file e altro.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is een lightgewicht software stack die draait op een Raspberry Pi om zelf veilig je websites, e-mail, bestanden en meer te hosten.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS é um leve conjunto de softwares que rodam em um Raspberry Pi para que você mesmo possa hospedar de forma segura seus sites, email e mais.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Легковесный сборник программного обеспечение для безопасного хостинга ваших сайтов, электронной почты, файлов и многого другого, запускающийся на Raspberry Pi.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS je lagan softver koji radi na Raspberry Pi uređajima da sigurno hostujete sami svoju web stranicu, email, datoteke i još mnogo toga.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Raspberry Pi üzerinde çalışan arkOS websitenizi, e-postalarınızı, dosyalarınızı ve daha fazlasını güvenle host etmek için hafif bir yazılım kümesidir.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "ARKOS是一个基于Linux的服务器操作系统，可在小巧的Raspberry Pi硬件上运行，提供电子邮件、聊天、文件共享、虚拟主机等功能。",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -134,7 +134,7 @@
     "slug": "arch-linux"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "arkOS is a lightweight software stack that runs on a Raspberry Pi to securely self-host your websites, email, files and more.",
     "license_url": "https://github.com/cznweb/genesis/blob/master/LICENSE",
     "logo": "arkos.png",


### PR DESCRIPTION
Closes #1369.

---

I agree with @strugee. The warning on https://arkos.io/ should be enough to warrant this, but if you want more, the latest tag is still less than 1: https://github.com/cznweb/genesis/releases.