### PR TITLE
update GNU social urls for switch to gitlab.com from gitorious.org

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "موقع إجتماعي  لامركزي ذاتي  الإستضافة.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Xarxa social descentralitzada i per allotjament propi.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Selbst-gehostetes, dezentralisiertes soziales Netzwerk.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Αυτοφιλοξενούμενο, Διανεμημένο κοινωνικό δίκτυο.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -2328,14 +2328,14 @@
   {
     "development_stage": "released",
     "description": "Self-hosted, decentralized social network.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "http://gnu.io/",
+    "url": "https://gnu.io/social/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Memgastiga, malcentra socia reto.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Red social descentralizada y auto-hospedada.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "شبکه اجتماعی غیرمتمرکز روی سرور شخصی",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Omalta tietokoneelta suoritettava, hajautettu sosiaalinen verkosto.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Réseau social décentralisé et auto-hébergé.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "רשת חברתית מבוזרת באחסון עצמאי.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "स्व-होस्ट, विकेन्द्रित सामाजिक संजाल.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Self-hosted, decentralized social network.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Social network self-hosted e decentralizzato.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "セルフホストで、分散化されたソーシャルネットワーク。",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Zelfgehost, decentraal sociaal netwerk.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Lokalt og desentralisert sosialt nettverk.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Zdecentralizowana sie&#263; spo&#322;eczno&#347;ciowa na w&#322;asnym hostingu.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Rede social de descentralizada e de hospedagem própria.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -2328,14 +2328,14 @@
   {
     "development_stage": "released",
     "description": "Программное обеспечение децентрализованной социальной сети, которое вы можете установить на свой сервер.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "http://gnu.io",
+    "url": "https://gnu.io/social/",
     "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Лично хостована и децентрализована друштвена мрежа.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Lično hostovana i decentralizovana društvena mreža.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Lokalt, decentraliserat socialt nätverk",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "Bireysel-host edilen, merkezsiz sosyal ağ.",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "自行架设的去中心化社交网络",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gnu.io/",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "https://zh.wikipedia.org/wiki/StatusNet",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -2328,15 +2328,15 @@
   {
     "development_stage": "released",
     "description": "自架的去中心化社群網路。",
-    "license_url": "https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING",
+    "license_url": "https://gitlab.com/gnu-social-statusnet/gnu-social/blob/master/COPYING",
     "logo": "gnu-social.png",
     "notes": "",
     "privacy_url": "",
-    "source_url": "http://gitorious.org/+socialites/statusnet/gnu-social",
+    "source_url": "https://gitlab.com/gnu-social-statusnet/gnu-social",
     "name": "GNU social",
     "tos_url": "",
-    "url": "https://www.gnu.org/software/social/",
-    "wikipedia_url": "",
+    "url": "https://gnu.io/social/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GNU_Social",
     "protocols": [
       "SSL/TLS"
     ],


### PR DESCRIPTION
[Source] [1]

[1]: https://gitorious.org/statusnet/gnu-social/source/5308e04e83f4a3f04e6d8bf80b177e7208dbac58:COPYING