### PR TITLE
 synchronize missing/unequal metadata across all locales

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "عُملة ند للند  رقميّة بدون  سلطة مركزيّة.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Moneda P2P digital sense autoritat centralitzada.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "P2P ψηφιακό νόμισμα χωρίς κεντρική αρχή.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Diĝita samtavola monero sen centra aŭtoritato.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Moneda P2P digital sin autoridad centralizada.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (signo: Ł; abr.: LTC) es una Criptodivisa sustentada por la red P2P, y un proyecto de software de código abierto publicado bajo la licencia MIT.1 Inspirada y prácticamente idéntica en su aspecto técnico2 a Bitcoin (BTC), la creación y transferencia de Litecoin se basa en un protocolo criptográfico de código abierto que no es administrado por ninguna autoridad central.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "پول دیجیتال بدون مرکز کنترل",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) on peer-to-peer kryptovaluutta ja avoimen lähdekoodin, MIT/X11 lisensoitu ohjelmistoprojekti. Bitcoinin (BTC) inspiroima, ja teknisiltä piirteiltään lähes identtinen, Litecoinin luonti ja siirto perustuu avoimen lähdekoodin protokollaan, eikä ole yksittäisen toimijan hallinnoima. Litecoinin kehittäjät pyrkivät parantamaan Bitcoinia kolmessa merkittävässä asiassa.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -253,7 +253,7 @@
     "description": "Monnaie numérique P2P sans autorité centrale.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "מטבע דיגיטלי המבוסס על תקשורת P2P ללא סמכות מרכזית.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "P2P डिजिटल मुद्रा बगैर किसी केन्द्रीय प्राधिकरण.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Digitala samtavola pekunio sen centrala autoritato.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Valuta digitale P2P senza un&#39;autorit&agrave; centrale.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (simbolo : Ł ; codice : LTC) &egrave; una criptovaluta peer-to-peer e progetto open source pubblicato con licenza MIT/X11. Ispirato e tecnicamente quasi identico a Bitcoin (BTC), la creazione e il trasferimento di Litecoin sono basati su un protocollo open source e non sono gestiti da un&#39;autorit&agrave; centrale. Litecoin &egrave;, secondo i suoi sviluppatori, progettato per migliorare Bitcoin e offre tre differenze chiave.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "中央権力が存在しないP2Pデジタル通貨。",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "P2P digitale munteenheid zonder centrale autoriteit.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Digital valuta basert på P2P, ikke sentralbank-kontroll.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Cyfrowa waluta P2P, bez organu centralnego.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Moeda digital P2P, sem autoridade central.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "P2P электронная валюта без централизованного управления.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -2775,31 +2775,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Servers",
-        "subcategories": [
-          "Mail Servers"
-        ]
-      }
-    ],
-    "slug": "iredmail"
-  },
-  {
-    "development_stage": "released",
-    "description": "Метапоисковая система, основанная в Нью-Йорке и Нидерландах.",
-    "license_url": "",
-    "logo": "ixquick.png",
-    "notes": "",
-    "privacy_url": "https://ixquick.com/eng/privacy-policy.html",
-    "source_url": "",
-    "name": "Ixquick",
-    "tos_url": "",
-    "url": "https://ixquick.com/",
-    "wikipedia_url": "https://ru.wikipedia.org/wiki/Ixquick",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
         "name": "Android",
         "subcategories": [
           "Mail Servers"
@@ -2839,6 +2814,31 @@
         "name": "Servers",
         "subcategories": [
           "Mail Servers"
+        ]
+      }
+    ],
+    "slug": "iredmail"
+  },
+  {
+    "development_stage": "released",
+    "description": "Метапоисковая система, основанная в Нью-Йорке и Нидерландах.",
+    "license_url": "",
+    "logo": "ixquick.png",
+    "notes": "",
+    "privacy_url": "https://ixquick.com/eng/privacy-policy.html",
+    "source_url": "",
+    "name": "Ixquick",
+    "tos_url": "",
+    "url": "https://ixquick.com/",
+    "wikipedia_url": "https://ru.wikipedia.org/wiki/Ixquick",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Web Services",
+        "subcategories": [
+          "Web Search"
         ]
       }
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (знак : Ł ; код : LTC) — P2P криптовалюта и программное обеспечение с открытым исходным кодом, выпущенным под лицензией MIT/X11. Так как Litecoin был вдохновлен и технически практически идентичен Bitcoin (BTC), его эмиссия и передача основана на открытом протоколе и не управляется никаким центральным органом.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "П2П дигитална валута без централне власти.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "P2P digitalna valuta bez centralne vlasti.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "P2P digital valuta utan någon central myndighet.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "Merkezi otoritesi olmayan P2P dijital para birimi.",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "持续、分布式的文件同步工具。",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing是一个自架设的文件分享平台，所以你所有的数据都存储在你自己的电脑里。没有中央服务器会干坏事，不管是合法还是非法的。所有通信都使用TLS保护。所使用的加密包括完全向前保密（perfect forward secrecy），以防止任何窃听者获取你的数据访问。每个节点由一个强大的加密证书识别。只有您明确允许的节点才可以连接到群集。",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "持续、分布式的文件同步工具。",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing是一个自架设的文件分享平台，所以你所有的数据都存储在你自己的电脑里。没有中央服务器会干坏事，不管是合法还是非法的。所有通信都使用TLS保护。所使用的加密包括完全向前保密（perfect forward secrecy），以防止任何窃听者获取你的数据访问。每个节点由一个强大的加密证书识别。只有您明确允许的节点才可以连接到群集。",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -144,7 +144,7 @@
     "name": "ArkOS",
     "tos_url": "",
     "url": "https://arkos.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/ArkOS",
     "protocols": [],
     "categories": [
       {
@@ -253,7 +253,7 @@
     "description": "無中央控管機制的 P2P 數位貨幣。",
     "license_url": "https://github.com/bitcoin/bitcoin/blob/master/COPYING",
     "logo": "bitcoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/bitcoin/bitcoin",
     "name": "Bitcoin",
@@ -531,7 +531,7 @@
     "name": "Byzantium",
     "tos_url": "",
     "url": "http://project-byzantium.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Byzantium_(Linux_distribution)",
     "protocols": [],
     "categories": [
       {
@@ -619,7 +619,7 @@
     "name": "ChatSecure",
     "tos_url": "",
     "url": "https://chatsecure.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/The_Guardian_Project_(software)#ChatSecure",
     "protocols": [
       "OTR",
       "XMPP"
@@ -1120,7 +1120,7 @@
     "name": "Desura",
     "tos_url": "",
     "url": "http://www.desura.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Desura",
     "protocols": [],
     "categories": [
       {
@@ -2235,7 +2235,7 @@
     "name": "GitLab",
     "tos_url": "",
     "url": "https://about.gitlab.com/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/GitLab",
     "protocols": [],
     "categories": [
       {
@@ -2581,7 +2581,7 @@
     "name": "HTTPS Everywhere",
     "tos_url": "",
     "url": "https://www.eff.org/https-everywhere",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/HTTPS_Everywhere",
     "protocols": [
       "SSL/TLS"
     ],
@@ -3287,7 +3287,7 @@
     "name": "Libreswan",
     "tos_url": "",
     "url": "https://libreswan.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Libreswan",
     "protocols": [],
     "categories": [
       {
@@ -3420,7 +3420,7 @@
     "description": "Litecoin (sign : Ł ; code : LTC) is a peer-to-peer cryptocurrency and open source software project released under the MIT/X11 license. Inspired by and technically nearly identical to Bitcoin (BTC), Litecoin creation and transfer is based on an open source protocol and is not managed by any central authority. Litecoin is intended by its developers to improve upon Bitcoin and offers three key differences.",
     "license_url": "https://github.com/litecoin-project/litecoin/blob/master-0.8/COPYING",
     "logo": "litecoin.png",
-    "notes": "",
+    "notes": "Please note that new, digital currencies may be very volatile. Complete loss of your investment is possible for a number of reasons (software errors or attacks, identity theft, etc.). Be prepared!",
     "privacy_url": "",
     "source_url": "https://github.com/litecoin-project/litecoin",
     "name": "Litecoin",
@@ -3949,7 +3949,7 @@
     "name": "nsupdate.info",
     "tos_url": "",
     "url": "https://nsupdate.info/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Nsupdate",
     "protocols": [
       "DNS",
       "SSL/TLS"
@@ -4994,7 +4994,7 @@
     "name": "pump.io",
     "tos_url": "",
     "url": "http://pump.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Pump.io",
     "protocols": [
       "SSL/TLS"
     ],
@@ -5835,7 +5835,7 @@
     "name": "Tent",
     "tos_url": "",
     "url": "https://tent.io/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Tent_%28protocol%29",
     "protocols": [],
     "categories": [
       {
@@ -6485,7 +6485,7 @@
     "name": "Yunohost",
     "tos_url": "",
     "url": "http://yunohost.org/",
-    "wikipedia_url": "",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/YunoHost",
     "protocols": [],
     "categories": [
       {

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -5661,53 +5661,53 @@
     "slug": "sylpheed"
   },
   {
-  "development_stage": "released",
-  "description": "Continuous decentralized file synchronization.",
-  "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
-  "logo": "syncthing.png",
-  "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
-  "privacy_url": "",
-  "source_url": "https://github.com/syncthing/syncthing",
-  "name": "Syncthing",
-  "tos_url": "",
-  "url": "https://syncthing.net/",
-  "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
-  "protocols": [
-    "SSL/TLS"
-  ],
-  "categories": [
-    {
-      "name": "Android",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "BSD",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "GNU/Linux",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "OS X",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    },
-    {
-      "name": "Windows",
-      "subcategories": [
-        "File Storage & Sync"
-      ]
-    }
-  ],
-  "slug": "syncthing"
+    "development_stage": "released",
+    "description": "Continuous decentralized file synchronization.",
+    "license_url": "https://github.com/syncthing/syncthing/blob/master/LICENSE",
+    "logo": "syncthing.png",
+    "notes": "Syncthing is a self-hosted file sharing platform, so none of your data is ever stored anywhere other than on your computers. There is no central server that might be compromised, legally or illegally. All communication is secured using TLS. The encryption used includes perfect forward secrecy to prevent any eavesdropper from gaining access to your data. Every node is identified by a strong cryptographic certificate. Only nodes you have explicitly allowed can connect to your cluster.",
+    "privacy_url": "",
+    "source_url": "https://github.com/syncthing/syncthing",
+    "name": "Syncthing",
+    "tos_url": "",
+    "url": "https://syncthing.net/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Syncthing",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "File Storage & Sync"
+        ]
+      }
+    ],
+    "slug": "syncthing"
   },
   {
     "development_stage": "released",


### PR DESCRIPTION
After this change, the only differences (I think) left are:

1. "fr-projects.json" has Wikipedia urls for the "Disconnect",
   "EtherCalc" and "Kamailio" projects, which no other locale has.

2. "zh-CN-projects.json" has translations for the "I2P" and "Ixquick"
   projects' "notes" section, which no other locale has, as introduced
   by b5495f7 from #932.

  - Notice that in the diff of b5495f7, the "notes" section for both
    these projects were empty before the change.

3. "fi-projects.json" has a translation for the "Off-the-Record
   Messaging" project's "notes" section, which no other locale has, as
   introduced by 1bd7801 from #1177.

  - Notice that in the diff of 1bd7801, the "notes" section for this
    project was empty before the change.

1 however should not be a problem because it does not look like there
are Wikipedia articles for these projects under any other language,
including English.

Note that this change does not actually check for *outdated*
translations (obviously). This change has only checked if a string type
key is empty when it should not be, or if an array type key (i.e.
"protocols" and "categories") is not equal to the rest of the keys from
all the other locales.

---

So I noticed that there were some missing or different metadata across all the `source/db/*.json` files. The reason there are two commits is because, whilst doing this, I noticed that the indentation for Syncthing was off (which was also my fault). So you can view both commit diffs separately so that the syncthing indentation stuff does not clutter the actual synchronizing diff.

I'm not sure what to do about 2 and 3 though, perhaps google translate to english and insert the results into all the other languages? Pinging @sedrubal (introduced 2) and @maqp (introduced 3) for english translations of those changes if possible. But I think it's better if they're just left alone, because the chinese translations at least seem to be china-specific. What do you think?