### PR TITLE
AntiPrism should only be listed under the "Servers" category

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -93,24 +93,6 @@
     ],
     "categories": [
       {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "OS X",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Operating Systems (Live)"
-        ]
-      },
-      {
         "name": "Servers",
         "subcategories": [
           "Raspberry Pi",


### PR DESCRIPTION
Ref #1388.

---

@antiprismca So I only put it under the "Servers" category as @Zegnat agreed with me in #1388. I didn't  change anything else.