### PR TITLE
Adopt a Code of Conduct for project participants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,3 +130,8 @@ If you wish to mirror this site, [nylira/prism-break-static](https://github.com/
 
  - [https://www.sedrubal.de/service/prism-break/en/](https://www.sedrubal.de/service/prism-break/en/)
  (credit: [sedrubal](https://github.com/sedrubal))
+
+# Code of Conduct
+
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#PRISM-Break/abuse@prism-break.org


### PR DESCRIPTION
PRISM-Break is largely driven by community participation in discussions
surrounding the inclusion or exclusion of various solutions. Given that
user privacy is (by definition) a very personal matter and that the
security community in general tends to have strong opinions, my
observation is that many issues that come up are fairly highly changed
even before somebody looses their cool or makes a nasty remark.

I think it would behoove the project to officially adopt a Code of
Conduct document that can be considered binding on participants in
discussion. Getting this into the repository early before any particular
major issue between participants comes up gives everybody something to
reference and a relative standard by with to judge a situation. This
could potentially save some grief vs. the possibility of working out the
details of such a code in the middle of a disputed discussion.

The Open Code of Conduct seems like a likely candidate. I'm not a huge
fan of some of the items as worded but for this project I think it will
be fine. See http://todogroup.org/opencodeofconduct/ for details.