### PR TITLE
Fix category links in /categories/

### DIFF
--- a/source/views/categories/index.jade
+++ b/source/views/categories/index.jade
@@ -12,7 +12,7 @@ block content
 
         .bars
           - each category in platformType.categories
-            a.bar(href="./categories/#{category.slug}")
+            a.bar(href="./#{category.slug}")
               .label
                 if category.fa === 'fa-mobile'
                   i(class="fa #{category.fa} large")


### PR DESCRIPTION
https://prism-break.org/en/categories/

I don't think this page is linked to anywhere, I came there by removing the end of the url.