### PR TITLE
add missing translation stubs for kontalk

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Telefonnummer basierter Messagingclient für die Masse, unter Verwendung von XMPP und OpenPGP Verschlüsselung. Unterstützt durch Communitybetrieben Servern.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",
@@ -6603,44 +6642,5 @@
       }
     ],
     "slug": "zenphoto"
-  },
-  {
-    "development_stage": "released",
-    "description": "Telefonnummer basierter Messagingclient für die Masse, unter Verwendung von XMPP und OpenPGP Verschlüsselung. Unterstützt durch Communitybetrieben Servern.",
-    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
-    "logo": "kontalk.png",
-    "notes": "",
-    "privacy_url": "",
-    "source_url": "https://github.com/kontalk",
-    "name": "Kontalk",
-    "tos_url": "",
-    "url": "https://kontalk.org/",
-    "wikipedia_url": "",
-    "protocols": [
-      "XMPP",
-      "GPG",
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Android",
-        "subcategories": [
-          "Instant Messaging"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Instant Messaging"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Instant Messaging"
-        ]
-      }
-    ],
-    "slug": "kontalk"
   }
 ]

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",
@@ -6603,44 +6642,5 @@
       }
     ],
     "slug": "zenphoto"
-  },
-  {
-    "development_stage": "released",
-    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
-    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
-    "logo": "kontalk.png",
-    "notes": "",
-    "privacy_url": "",
-    "source_url": "https://github.com/kontalk",
-    "name": "Kontalk",
-    "tos_url": "",
-    "url": "https://kontalk.org/",
-    "wikipedia_url": "",
-    "protocols": [
-      "XMPP",
-      "GPG",
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Android",
-        "subcategories": [
-          "Instant Messaging"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Instant Messaging"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Instant Messaging"
-        ]
-      }
-    ],
-    "slug": "kontalk"
   }
 ]

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "Sulautettuihin järjestelmiin tarkoitettu GNU/Linux-libre jakelu.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "Свободный GNU/Linux дистрибутив для встраиваемых устройств.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "一个为嵌入式设备设计的GNU/Linux-libre发行版。",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -3302,6 +3302,45 @@
   },
   {
     "development_stage": "released",
+    "description": "Phone number based messaging client for the masses, using XMPP and OpenPGP encryption. Backed by community-driven servers.",
+    "license_url": "https://github.com/kontalk/androidclient/blob/master/COPYING",
+    "logo": "kontalk.png",
+    "notes": "",
+    "privacy_url": "",
+    "source_url": "https://github.com/kontalk",
+    "name": "Kontalk",
+    "tos_url": "",
+    "url": "https://kontalk.org/",
+    "wikipedia_url": "",
+    "protocols": [
+      "XMPP",
+      "GPG",
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "Android",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Instant Messaging"
+        ]
+      }
+    ],
+    "slug": "kontalk"
+  },
+  {
+    "development_stage": "released",
     "description": "A GNU/Linux-libre distribution for embedded devices.",
     "license_url": "https://librecmc.org/librecmc/artifact/dfac199a7539a404",
     "logo": "librecmc.png",


### PR DESCRIPTION
This also moves kontalk from the bottom to its alphabetical place in
de-projects.json and en-projects.json.

---

BTW, thanks to #1482, you can now close #276 and #1408. :)