### PR TITLE
Various program category placement amendments

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -18,6 +18,30 @@
         "subcategories": [
           "Web Browser Addons"
         ]
+      },
+      {
+        "name": "BSD",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "GNU/Linux",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
       }
     ],
     "slug": "adblock-edge"
@@ -2673,6 +2697,12 @@
     ],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Anonymizing Networks"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Anonymizing Networks"
@@ -3978,6 +4008,12 @@
     "protocols": [],
     "categories": [
       {
+        "name": "Android",
+        "subcategories": [
+          "Web Browser Addons"
+        ]
+      },
+      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"
@@ -4306,6 +4342,12 @@
       "DNS"
     ],
     "categories": [
+      {
+        "name": "Routers",
+        "subcategories": [
+          "DNS"
+        ]
+      },
       {
         "name": "Web Services",
         "subcategories": [


### PR DESCRIPTION
From #1461:

- Add Adblock Edge to BSD, GNU/Linux, OS X and Windows.
- Add NoScript to Android.
- Add OpenNIC to Routers.
- Add I2P to Android.

(Self-Destructing Cookies is already in Android now.)

Closes #1461.