### PR TITLE
Add Firefox as a web browser alternative on iOS.

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "متصفح ويب مفتوح المصدر.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "متصفح ويب مفتوح المصدر.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Navegador web de codi lliure i obert.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Navegador web de codi lliure i obert.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Schneller, flexibler und sicherer Browser mit einem lebhaften Add-On Ökosystem.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Schneller, flexibler und sicherer Browser mit einem lebhaften Add-On Ökosystem.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Web browser ανοιχτού.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Web browser ανοιχτού.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -1803,6 +1803,31 @@
     "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Orbot.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.\n\nConsidering unchecking \"Block reported attack sites\" and \"Block reported web forgeries\" if you don't want Mozilla to send reported URL hashes to Google.",
     "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
     "source_url": "http://hg.mozilla.org/mobile-browser/",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Retumilo malfermitkoda.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Retumilo malfermitkoda.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Navegador web veloz, flexible y seguro de fuente libre y abierta con un gran sistema de extensiones.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Navegador web veloz, flexible y seguro de fuente libre y abierta con un gran sistema de extensiones.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "مرورگر متن باز",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "مرورگر متن باز",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -1800,10 +1800,10 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Yksi maailman suosituimmista verkkoselaimista, avointa lähdekoodia.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
-    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "notes": "Firefox ei piilota IP-osoitettasi kolmansilta osapuolilta oletuksena. Jos haluat anonymisoida IP-osoitteesi, on suositeltavaa käyttää Onion Browser.\n\nFirefoxin oletushakukone on Google. On suositeltavaa vaihtaa tilalle Ixquick, Startpage tai DuckDuck go, tai jokin muu anonyymi hakukone.",
     "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
     "source_url": "https://github.com/mozilla-mobile/firefox-ios",
     "name": "Firefox Mobile",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Yksi maailman suosituimmista verkkoselaimista, avointa lähdekoodia.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Navigateur web libre.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Navigateur web libre.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "דפדפן אינטרנט בקוד פתוח.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "דפדפן אינטרנט בקוד פתוח.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "ओपन सोर्स वेब ब्राउजर.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "ओपन सोर्स वेब ब्राउजर.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Retnavigilo de apertita fontokodo.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Retnavigilo de apertita fontokodo.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -1800,10 +1800,10 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Browser web veloce, flessibile e sicuro con un vivace ecosistema di componenti aggiuntivi.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
-    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "notes": "Firefox non nasconde il tuo indirizzo IP a terze parti in modo predefinito. Se vuoi nasconderlo, dovresti usare Onion Browser.\n\nIl motore di ricerca predefinito di Firefox &egrave; Google. Si consiglia di cambiarlo con DuckDuckGo o Startpage per effettuare ricerche anonime.",
     "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
     "source_url": "https://github.com/mozilla-mobile/firefox-ios",
     "name": "Firefox Mobile",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Browser web veloce, flessibile e sicuro con un vivace ecosistema di componenti aggiuntivi.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "オープンソースのウェブブラウザ。",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "オープンソースのウェブブラウザ。",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Snelle, flexibele en veilige webbrowser met een groot scala aan plugins.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Snelle, flexibele en veilige webbrowser met een groot scala aan plugins.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Fri Nettleser.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Fri Nettleser.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Przegl&#261;darka z otwartym kodem &#378;r&oacute;d&#322;owym.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Przegl&#261;darka z otwartym kodem &#378;r&oacute;d&#322;owym.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Navegador web de código aberto.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Navegador web de código aberto.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -1800,10 +1800,10 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Быстрый, гибкий и безопасный браузер с огромным выбором дополнений.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
-    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "notes": "Firefox не прячет ваш IP адрес от третьих лиц по умолчанию. Если вы хотите анонимизировать свой IP, используйте вместо него Onion Browser.\n\nFirefox отправляет поисковые запросы через Google по умолчанию. Подумайте о смене его на DuckDuckGo или Startpage для анонимного веб поиска.",
     "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
     "source_url": "https://github.com/mozilla-mobile/firefox-ios",
     "name": "Firefox Mobile",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Быстрый, гибкий и безопасный браузер с огромным выбором дополнений.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Интернет прегледач отвореног кода.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Интернет прегледач отвореног кода.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Internet pregledač otvorenog koda.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Internet pregledač otvorenog koda.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Webbläsare med öppen källkod.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Webbläsare med öppen källkod.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "Hızlı, esnek ve güvenli web tarayıcısı, canlı bir eklenti ekosistemi de vardır.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "Hızlı, esnek ve güvenli web tarayıcısı, canlı bir eklenti ekosistemi de vardır.",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -1874,10 +1874,10 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "开源的web浏览器，扩展丰富。",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
-    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "notes": "默认情况下Firefox Mobile并不会对第三方隐藏你的IP地址，如果你想要隐藏IP，建议使用Onion Browser。\n\n火狐默认情况下使用Google作为搜索引擎，建议改成DuckDuckGo或者Startpage以提升匿名性。",
     "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
     "source_url": "https://github.com/mozilla-mobile/firefox-ios",
     "name": "Firefox Mobile",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -1874,6 +1874,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "开源的web浏览器，扩展丰富。",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -1800,6 +1800,31 @@
   },
   {
     "development_stage": "released",
+    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "license_url": "https://www.mozilla.org/MPL/",
+    "logo": "mozilla-firefox.png",
+    "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",
+    "privacy_url": "https://www.mozilla.org/en-US/privacy/policies/websites/",
+    "source_url": "https://github.com/mozilla-mobile/firefox-ios",
+    "name": "Firefox Mobile",
+    "tos_url": "https://www.mozilla.org/en-US/about/legal.html",
+    "url": "https://www.mozilla.org/firefox/ios/",
+    "wikipedia_url": "https://en.wikipedia.org/wiki/Firefox_for_iOS",
+    "protocols": [
+      "SSL/TLS"
+    ],
+    "categories": [
+      {
+        "name": "iOS",
+        "subcategories": [
+          "Web Browsers"
+        ]
+      }
+    ],
+    "slug": "firefox-ios"
+  },
+  {
+    "development_stage": "released",
     "description": "一個開放原始碼的瀏覽器。",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -1800,7 +1800,7 @@
   },
   {
     "development_stage": "released",
-    "description": "Fast, flexible and secure web browser with a vibrant add-on ecosystem.",
+    "description": "一個開放原始碼的瀏覽器。",
     "license_url": "https://www.mozilla.org/MPL/",
     "logo": "mozilla-firefox.png",
     "notes": "Firefox Mobile does not hide your IP address from third-parties by default. If you want to anonymize your IP, consider using Onion Browser.\n\nFirefox sends searches through Google by default. Consider changing it to DuckDuckGo or Startpage for anonymous web searches.",


### PR DESCRIPTION
Firefox is available on iOS as well, although it's essentially Webkit with a Firefox UI around it. It doesn't share in Safari's syncing, cookies and other state data though.

EDIT: Link: https://www.mozilla.org/en-US/firefox/ios/
