### PR TITLE
Remove Privacy Badger from Android recommendations

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -4897,12 +4897,6 @@
     "protocols": [],
     "categories": [
       {
-        "name": "Android",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
         "name": "BSD",
         "subcategories": [
           "Web Browser Addons"


### PR DESCRIPTION
This removes Privacy Badger from the list of Android-compatible projects. Disconnect wasn't in the Android list to begin with; I suspect #1606's OP got the addon confused with the web site.

Fixes #1606.