### PR TITLE
Make localizations inherit from English JSON data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LANGUAGES := $(notdir $(basename $(wildcard source/locales/*.json)))
 ASSETS := $(notdir $(wildcard source/assets/*))
 
 # Mark all rules that don’t actually check whether they need building
-.PHONY: default test init reset all $(LANGUAGES) assets css html html_% clean watch watch_css sync
+.PHONY: default test init reset all $(LANGUAGES) assets css html html_% clean watch watch_css sync localize_%
 
 # Turn on expansion so we can reference target patterns in our dependencies list
 .SECONDEXPANSION:
@@ -105,6 +105,10 @@ clean:
 public/.htaccess: source/dotfiles/.htaccess
 	mkdir -p $(dir $@)
 	cp $< $@
+
+# Localizations
+localize_%:
+	lsc ./source/functions/find-missing-localizations.ls $*
 
 #----------------------------------------------------------------------
 # CONVENIENCE FUNCTIONS

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the PRISM Break project. Here's a quick overview of the code. JSON co
 
 The prism-break build process relies on several npm packages. Make sure to have [node.js](https://nodejs.org/) installed on your system if you want to contribute to the code.
 
-If you'd like to translate the project to your favorite language, there's no need to install node.js or even download the code. Just edit the appropriate JSON files on GitHub and submit a pull request.
+If you'd like to translate the project to your favorite language, there's no need to install node.js or even download the code. Just add translated data to the appropriate JSON files on GitHub and submit a Pull Request - if anything's missing, the English version will be used instead. That being said, setting up the project locally will allow you to run `make localize_LANG` (where `LANG` is a language code) to get a nice list of things for you to translate.
 
 More information for translators can be found in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "A directory of free privacy-oriented software.",
   "main": "Makefile",
   "dependencies": {
+    "es7-array.prototype.includes": "^2.0.0",
     "graceful-fs": "~4.1.4",
     "jade": "~1.11.0",
     "livescript": "~1.5.0",
     "lodash.assign": "^4.2.0",
+    "lodash.isequal": "^4.4.0",
     "marked": "~0.3.5",
     "mkdirp": "~0.5.x",
     "moment": "^2.17.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "graceful-fs": "~4.1.4",
     "jade": "~1.11.0",
     "livescript": "~1.5.0",
+    "lodash.assign": "^4.2.0",
     "marked": "~0.3.5",
     "mkdirp": "~0.5.x",
     "moment": "^2.17.1",

--- a/source/functions/build.ls
+++ b/source/functions/build.ls
@@ -1,13 +1,30 @@
 'use strict'
 
+assign = require 'lodash.assign'
 {write-localized-site} = require './write.ls'
 {slugify-db} = require './sort.ls'
+
+load-data = (path, iso) ->
+  en-data = require path.replace('/' + iso, '/en')
+  localized-data = require path
+
+  data = []
+
+  for obj in en-data
+    # Look for a localized version
+    potential-localized-obj = null
+    for localized-obj in localized-data
+      if localized-obj.name is obj.name
+        potential-localized-obj = assign {}, obj, localized-obj
+        break
+
+    potential-localized-obj or obj
 
 export build-site = (iso) ->
 
   locale =              require "../locales/#{iso}.json"
-  projects =            require "../db/#{iso}-projects.json"
-  protocols =           require "../db/protocols/#{iso}-protocols.json"
+  projects =            load-data "../db/#{iso}-projects.json", iso
+  protocols =           load-data "../db/protocols/#{iso}-protocols.json", iso
   {projects-rejected} = require '../db/en-projects-rejected.ls'
   {platform-types} =    require '../db/en-platform-types.ls'
 

--- a/source/functions/build.ls
+++ b/source/functions/build.ls
@@ -1,24 +1,8 @@
 'use strict'
 
-assign = require 'lodash.assign'
+load-data = require './load-data.ls'
 {write-localized-site} = require './write.ls'
 {slugify-db} = require './sort.ls'
-
-load-data = (path, iso) ->
-  en-data = require path.replace('/' + iso, '/en')
-  localized-data = require path
-
-  data = []
-
-  for obj in en-data
-    # Look for a localized version
-    potential-localized-obj = null
-    for localized-obj in localized-data
-      if localized-obj.name is obj.name
-        potential-localized-obj = assign {}, obj, localized-obj
-        break
-
-    potential-localized-obj or obj
 
 export build-site = (iso) ->
 

--- a/source/functions/find-missing-localizations.ls
+++ b/source/functions/find-missing-localizations.ls
@@ -1,0 +1,9 @@
+'use strict'
+
+load-data = require './load-data.ls'
+
+iso = process.argv[2]
+
+load-data "../db/#{iso}-projects.json", iso, true
+load-data "../db/protocols/#{iso}-protocols.json", iso, true
+

--- a/source/functions/load-data.ls
+++ b/source/functions/load-data.ls
@@ -2,7 +2,7 @@
 
 assign = require 'lodash.assign'
 
-module.exports = load-data = (path, iso) ->
+module.exports = load-data = (path, iso, find-missing = false) ->
   en-data = require path.replace('/' + iso, '/en')
   localized-data = require path
 
@@ -15,5 +15,9 @@ module.exports = load-data = (path, iso) ->
       if localized-obj.name is obj.name
         potential-localized-obj = assign {}, obj, localized-obj
         break
+
+    if find-missing and not potential-localized-obj
+      console.log 'Missing ' + iso + ' localization for ' + obj.name
+      continue
 
     potential-localized-obj or obj

--- a/source/functions/load-data.ls
+++ b/source/functions/load-data.ls
@@ -6,8 +6,6 @@ module.exports = load-data = (path, iso, find-missing = false) ->
   en-data = require path.replace('/' + iso, '/en')
   localized-data = require path
 
-  data = []
-
   for obj in en-data
     # Look for a localized version
     potential-localized-obj = null

--- a/source/functions/load-data.ls
+++ b/source/functions/load-data.ls
@@ -1,6 +1,13 @@
 'use strict'
 
 assign = require 'lodash.assign'
+isequal = require 'lodash.isequal'
+if not Array.prototype.includes then require 'es7-array.prototype.includes'
+
+# TODO: support overrides
+# Then we can expand this list to include e.g. wikipedia_url, but not warn in situations where there isn't a translated Wikipedia article
+# When we do this we should warn about the presence of non-translatable keys (e.g. the `protocols` key should always be consistent)
+translatable = ['notes', 'description']
 
 module.exports = load-data = (path, iso, find-missing = false) ->
   en-data = require path.replace('/' + iso, '/en')
@@ -14,8 +21,26 @@ module.exports = load-data = (path, iso, find-missing = false) ->
         potential-localized-obj = assign {}, obj, localized-obj
         break
 
-    if find-missing and not potential-localized-obj
-      console.log 'Missing ' + iso + ' localization for ' + obj.name
-      continue
+    if find-missing
+      if not potential-localized-obj
+        console.log 'Missing ' + iso + ' localization for ' + obj.name
+        continue
+      else
+        # First we check if entire objects are duplicated
+        # We use localized-obj because potential-localized-obj has already been filled in by lodash.assign
+        if isequal obj, localized-obj
+          console.log iso + ' localization of ' + obj.name + ' duplicates the English version'
+        # Then we check for per-key problems
+        else
+          # For each (non-empty) localizable key in the English version...
+          for key of obj when translatable.includes key and obj[key] is not ''
+              # ...check if it hasn't been localized at all
+              if not localized-obj[key]
+                console.log 'Missing ' + iso + ' localization for key `' + key + '` in project ' + obj.name
+              # ...check if the localized version is a duplicate
+              else if isequal obj[key], localized-obj[key]
+                console.log iso + ' localization of key `' + key + '` in project ' + obj.name + ' duplicates the English version'
+
+        continue
 
     potential-localized-obj or obj

--- a/source/functions/load-data.ls
+++ b/source/functions/load-data.ls
@@ -1,0 +1,19 @@
+'use strict'
+
+assign = require 'lodash.assign'
+
+module.exports = load-data = (path, iso) ->
+  en-data = require path.replace('/' + iso, '/en')
+  localized-data = require path
+
+  data = []
+
+  for obj in en-data
+    # Look for a localized version
+    potential-localized-obj = null
+    for localized-obj in localized-data
+      if localized-obj.name is obj.name
+        potential-localized-obj = assign {}, obj, localized-obj
+        break
+
+    potential-localized-obj or obj


### PR DESCRIPTION
WIP for feedback; do not merge. /cc @nylira because most of this was written by you.

This change makes it so that when building localized pages, the English project data is used as a default if a localized version is not provided. This means that when adding new projects, contributors can update the English data and be done with it, as opposed to patching all 23 language files. Updates to existing projects also only need to patch files that have already been localized.

One big downside to this is that it's no longer quite as obvious what's not localized. I have a plan to add some Make targets which will provide a list, per-language, of what still needs to be added. This will make localization via the GitHub web interface slightly more challenging, but I think it's worth it.

However! This implementation is currently broken. You can see the problem by cloning the source branch and running a build:

```
% make es
rm -rf tmp/*
mkdir -p tmp/assets/css tmp/assets/js
cp -r source/assets/fonts tmp/assets/fonts
cp -r source/assets/icons tmp/assets/ico
cp -r source/assets/images tmp/assets/img
./node_modules/.bin/lsc ./source/functions/build/site-es.ls
Failed at: ./source/functions/build/site-es.ls
TypeError: string.replace is not a function
    at slugify (/Users/alex/Development/github/prism-break/source/functions/slugify.ls:5:19)
    at /Users/alex/Development/github/prism-break/source/functions/sort.ls:27:13
    at /Users/alex/Development/github/prism-break/node_modules/prelude-ls/lib/List.js:15:19
    at /Users/alex/Development/github/prism-break/node_modules/prelude-ls/lib/List.js:665:42
    at slugifyList (/Users/alex/Development/github/prism-break/source/functions/sort.ls:24:10)
    at slugifyProject (/Users/alex/Development/github/prism-break/source/functions/sort.ls:40:32)
    at create (/Users/alex/Development/github/prism-break/source/functions/write.ls:316:12)
    at writeProjectsShow (/Users/alex/Development/github/prism-break/source/functions/write.ls:344:19)
    at writeLocalizedSite (/Users/alex/Development/github/prism-break/source/functions/write.ls:21:3)
    at buildSite (/Users/alex/Development/github/prism-break/source/functions/build.ls:42:10)
make: *** [build_es] Error 1
```

Note that for Spanish in particular I've committed a change (to be removed before merge, obviously) that reduces the data to a minimal testcase - Firefox for iOS is the problem and FreeBSD is left in there as a reference for something that works, for whatever reason. :/

Basically, the problem is that at some point in line 15 of `source/functions/sort.ls`, `slugify` gets passed `{ name: 'Web Browsers', slug: 'web-browsers' }` instead of (presumably) `Web Browsers`. Seems like `slugify` is getting called on some data twice somewhere, though for the life of me I can't wrap my head around how.

If people want to look at the code and spot the bug, that'd be great. I certainly can't, at least so far :P

Feel free to commit directly to my branch, although I might squash your commit into one of mine in the course of cleaning this up for merge.