### PR TITLE
Remove bogus content outside of JSON in ar language data

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -6850,4 +6850,4 @@
     ],
     "slug": "android-password-store"
   }
-]r
+]


### PR DESCRIPTION
I'm working on a complete overhaul of the Makefile and ran into not being able to build all the languages. It looks like this came from 00be7c1 — somebody must not have actually tried building this 😉 .

(The good news is with the new Makefile and proper dependencies a failed make knows what language didn't finish and `make all` picks up where it left off!)