### PR TITLE
Make 'all' target and other cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,9 @@ css: init public/assets/css/screen.css
 .PHONY: html
 html: init $(foreach LANGUAGE,$(LANGUAGES),html_$(LANGUAGE))
 
-.PHONY: html_%
-html_%: public/%/index.html
+HTMLLANGS = $(foreach LANGUAGE,$(LANGUAGES),html_$(LANGUAGE))
+.PHONY: $(HTMLLANGS)
+$(HTMLLANGS): html_%: public/%/index.html
 
 public: public/.htaccess ;
 
@@ -123,8 +124,9 @@ public/.htaccess: source/dotfiles/.htaccess
 	cp $< $@
 
 # Localizations
-.PHONY: localize_%
-localize_%:
+LOCALLANGS = $(foreach LANGUAGE,$(LANGUAGES),localize_$(LANGUAGE))
+.PHONY: $(LOCALLANGS)
+$(LOCALLANGS): localize_%:
 	lsc ./source/functions/find-missing-localizations.ls $*
 
 #----------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -46,40 +46,40 @@ endif
 #----------------------------------------------------------------------
 
 # Explicitly set the default target that does the minimum possible
-default: | init assets full public ;
+default: | init assets full public
 
 # This is the kitchen-sink build that does everything
-all: | init lint assets full public ;
+all: | init lint assets full public
 
 # Run anything that needs doing post-checkout to make this buildable
-init: node_modules ;
+init: node_modules
 
 # Use building English language as a check to see if everything works
-test: lint en ;
+test: lint en
 
 lint:
 	find source -type f -name '*.json' -print -exec jsonlint -q '{}' \;
 
 # Start fresh and rebuild everything
-reset: | clean default ;
+reset: | clean default
 
 # Targets to build all the dynamically generated stuff for all languages
-full: css html ;
+full: css html
 
 # Targets for rebuilding only single language and only what isn’t already done
-$(LANGUAGES): | init assets css html_$$@ public ;
+$(LANGUAGES): | init assets css html_$$@ public
 
 #----------------------------------------------------------------------
 # CONVENIENCE ALIASES
 #----------------------------------------------------------------------
 
-assets: $(foreach ASSET,$(ASSETS),public/assets/$(ASSET)) ;
+assets: $(foreach ASSET,$(ASSETS),public/assets/$(ASSET))
 
-css: public/assets/css/screen.css ;
+css: public/assets/css/screen.css
 
-html: $(foreach LANGUAGE,$(LANGUAGES),html_$(LANGUAGE)) ;
+html: $(foreach LANGUAGE,$(LANGUAGES),html_$(LANGUAGE))
 
-html_%: public/%/index.html ;
+html_%: public/%/index.html
 
 public: public/.htaccess ;
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LANGUAGES := $(notdir $(basename $(wildcard source/locales/*.json)))
 ASSETS := $(notdir $(wildcard source/assets/*))
 
 # Mark all rules that don’t actually check whether they need building
-.PHONY: default test lint init reset all $(LANGUAGES) assets css html html_% clean watch watch_css sync localize_%
+.PHONY: default all test lint init reset full $(LANGUAGES) assets css html html_% clean watch watch_css sync localize_%
 
 # Turn on expansion so we can reference target patterns in our dependencies list
 .SECONDEXPANSION:
@@ -45,8 +45,11 @@ endif
 # COMMANDS
 #----------------------------------------------------------------------
 
-# Explicitly set the default target to do everything that isn’t already done
-default: | init lint assets all public ;
+# Explicitly set the default target that does the minimum possible
+default: | init assets full public ;
+
+# This is the kitchen-sink build that does everything
+all: | init lint assets full public ;
 
 # Run anything that needs doing post-checkout to make this buildable
 init: node_modules ;
@@ -61,7 +64,7 @@ lint:
 reset: | clean default ;
 
 # Targets to build all the dynamically generated stuff for all languages
-all: css html ;
+full: css html ;
 
 # Targets for rebuilding only single language and only what isn’t already done
 $(LANGUAGES): | init assets css html_$$@ public ;

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ LANGUAGES := $(notdir $(basename $(wildcard source/locales/*.json)))
 # Collect list of static assets that get copied over
 ASSETS := $(notdir $(wildcard source/assets/*))
 
-# Mark all rules that don’t actually check whether they need building
-.PHONY: default all test lint init reset full $(LANGUAGES) assets css html html_% clean watch watch_css sync localize_%
-
 # Turn on expansion so we can reference target patterns in our dependencies list
 .SECONDEXPANSION:
 
@@ -46,39 +43,51 @@ endif
 #----------------------------------------------------------------------
 
 # Explicitly set the default target that does the minimum possible
+.PHONY: default
 default: | init assets full public
 
 # This is the kitchen-sink build that does everything
+.PHONY: all
 all: | init lint assets full public
 
 # Run anything that needs doing post-checkout to make this buildable
+.PHONY: init
 init: node_modules
 
 # Use building English language as a check to see if everything works
+.PHONY: test
 test: lint en
 
+.PHONY: lint
 lint:
 	find source -type f -name '*.json' -print -exec jsonlint -q '{}' \;
 
 # Start fresh and rebuild everything
+.PHONY: reset
 reset: | clean default
 
 # Targets to build all the dynamically generated stuff for all languages
+.PHONY: full
 full: css html
 
 # Targets for rebuilding only single language and only what isn’t already done
+.PHONY: $(LANGUAGES)
 $(LANGUAGES): | init assets css html_$$@ public
 
 #----------------------------------------------------------------------
 # CONVENIENCE ALIASES
 #----------------------------------------------------------------------
 
+.PHONY: assets
 assets: $(foreach ASSET,$(ASSETS),public/assets/$(ASSET))
 
+.PHONY: css
 css: public/assets/css/screen.css
 
+.PHONY: html
 html: $(foreach LANGUAGE,$(LANGUAGES),html_$(LANGUAGE))
 
+.PHONY: html_%
 html_%: public/%/index.html
 
 public: public/.htaccess ;
@@ -105,6 +114,7 @@ public/assets/css/%.css: source/stylesheets/%.styl $(shell git ls-files *.styl)
 public/%/index.html: source/functions/build/site-%.ls $$(shell git ls-files | grep '\b$$*\b')
 	lsc $<
 
+.PHONY: clean
 clean:
 	rm -rf public/*
 
@@ -113,6 +123,7 @@ public/.htaccess: source/dotfiles/.htaccess
 	cp $< $@
 
 # Localizations
+.PHONY: localize_%
 localize_%:
 	lsc ./source/functions/find-missing-localizations.ls $*
 
@@ -120,14 +131,17 @@ localize_%:
 # CONVENIENCE FUNCTIONS
 #----------------------------------------------------------------------
 
+.PHONY: watch
 watch:
 	git ls-files | entr -p make $(WATCH_ARGS)
 
 # Rebuild CSS live on input changes
+.PHONY: watch_css
 watch_css:
 	stylus -c -w source/stylesheets/screen.styl -u nib -o public/assets/css/
 
 # copy ./public to another repository and commit changes
+.PHONY: sync
 sync:
 	rsync -azru --delete --stats public/ ../prism-break-static/public/
 	(cd ../prism-break-static; git add -A; git commit -m 'regenerate'; git push)

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ all: | init lint assets full public ;
 init: node_modules ;
 
 # Use building English language as a check to see if everything works
-test: en ;
+test: lint en ;
 
 lint:
 	find source -type f -name '*.json' -print -exec jsonlint -q '{}' \;

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,11 @@ endif
 
 # Explicitly set the default target that does the minimum possible
 .PHONY: default
-default: | init assets full public
+default: assets full public
 
 # This is the kitchen-sink build that does everything
 .PHONY: all
-all: | init lint assets full public
+all: lint assets full public
 
 # Run anything that needs doing post-checkout to make this buildable
 .PHONY: init
@@ -64,7 +64,7 @@ lint:
 
 # Start fresh and rebuild everything
 .PHONY: reset
-reset: | clean default
+reset: clean default
 
 # Targets to build all the dynamically generated stuff for all languages
 .PHONY: full
@@ -72,20 +72,20 @@ full: css html
 
 # Targets for rebuilding only single language and only what isn’t already done
 .PHONY: $(LANGUAGES)
-$(LANGUAGES): | init assets css html_$$@ public
+$(LANGUAGES): assets css html_$$@ public
 
 #----------------------------------------------------------------------
 # CONVENIENCE ALIASES
 #----------------------------------------------------------------------
 
 .PHONY: assets
-assets: $(foreach ASSET,$(ASSETS),public/assets/$(ASSET))
+assets: init $(foreach ASSET,$(ASSETS),public/assets/$(ASSET))
 
 .PHONY: css
-css: public/assets/css/screen.css
+css: init public/assets/css/screen.css
 
 .PHONY: html
-html: $(foreach LANGUAGE,$(LANGUAGES),html_$(LANGUAGE))
+html: init $(foreach LANGUAGE,$(LANGUAGES),html_$(LANGUAGE))
 
 .PHONY: html_%
 html_%: public/%/index.html


### PR DESCRIPTION
Closes #1781 as well as fixes a few other bugs in the make process (including things that appeared to work but only accidentally and that should have worked if make didn't have some wonky bugs).

Please test this before merging. I ran a couple quick tests on my machine but certainly didn't cover every possible combination. Notably `make -jN` (where N is something like the number of CPU cores you have) should actually work now to build multiple languages at once. It sometimes worked before but only _after_ at least one try (or if by chance the first try randomly got one job done before the second one failed!).