### PR TITLE
Remove RequestPolicy addon not supported in FF57+

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "برنامج  إتصالات الند  للند حر و آمن.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Plataforma de comunicacions P2P, lliure i segura.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -4451,46 +4451,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Kontrolliere Website-übergreifende Anfragen von Seiten, die Du besuchtst.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Sichere P2P-Kommunikationsplattform, die IM, Foren, VoIP, File Sharing und mehr bietet.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Ελεύθερη, ασφαλής, πλατφόρμα επικοινωνιών P2P.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -4752,47 +4752,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "notes": "",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Secure P2P communications platform offering IM, forums, VoIP, file sharing, and more.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Libera, sekura, samtavola platformo por komunikoj.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -4450,46 +4450,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Controla qué peticiones externas son permitidas para los sitios que visitas.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Plataforma de comunicaciones P2P, libre y segura, que ofrece mensajería instantánea, foros, VoIP, compartición de archivos y más.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "سکوی ارتباطی دوطرفه، امن و آزاد",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -4454,46 +4454,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Hallitse, mitkä cross-site requestit sallitaan sivuilla, joilla vierailet.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Ilmainen ja turvallinen P2P-keskustelualusta.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -4452,46 +4452,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Permet de contrôler quelles sont les requêtes inter-sites autorisées.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Plate-forme libre et sécurisée de communications pair-à-pair.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -4450,46 +4450,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "שלוט באילו בקשות חוצות שרת (cross-site) מורשות ע״י השרתים בהם אתה מבקר.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "פלטפורמת תקשורת P2P חופשית ובטוחה.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "मुक्त, सुरक्षित, P2P संचार मंच.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Libera, sekura, samtablala platformo por komuniki.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -4456,46 +4456,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Controlla quali richieste cross-site autorizzare nei siti che visiti.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Piattaforma di comunicazione P2P sicura per chat, forum, VoIP, condivisione di file e altro.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "自由でセキュアなP2Pコミュニケーションプラットフォーム。",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -4450,46 +4450,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Regel welke cross-site aanvragen van de sites die je bezoekt worden toegestaan.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Vrij en veilig P2P communicatieplatform.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -4450,46 +4450,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Kontroller forespørsler fra sider.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Gratis og sikker P2P kommunikasjonsplattform.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Bezpieczna i darmowa platforma rozmów poprzez protokół P2P.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Plataforma de comunicação P2P livre e segura.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -4457,46 +4457,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Контролируйте, какие межсайтовые запросы будут разрешены на сайтах, которые вы посещаете. ",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Свободная и безопасная P2P коммуникационная платформа, предоставляющая IM, форумы, VoIP, обмен файлами и многое другое.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -4450,46 +4450,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Контролируйте, какие межсайтовые запросы будут разрешены на сайтах, которые вы посещаете. ",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Бесплана и сигурна П2П комуникациона платформа.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -4450,46 +4450,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Контролируйте, какие межсайтовые запросы будут разрешены на сайтах, которые вы посещаете. ",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Besplana i sigurna P2P komunikaciona platforma.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -4450,46 +4450,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "Gratis och säker P2P kommunikations plattform.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -4450,46 +4450,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Hangi siteler-arası isteklere izin verildiğini ziyaret edilen sitelere göre kontrol edin.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "IM, forumlar, VoIP, dosya paylaşımı ve fazlasını sunan güvenli P2P iletişim platformu.",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -4551,46 +4551,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "根据你访问的网站来控制哪些跨站请求是被允许的。",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "安全的 P2P 通讯平台，提供即时通讯，论坛，网络电话，文件共享等功能。",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -4416,46 +4416,6 @@
     "slug": "replicant"
   },
   {
-    "development_stage": "experimental",
-    "description": "Control which cross-site requests are allowed by sites you visit.",
-    "license_url": "https://github.com/RequestPolicyContinued/requestpolicy/blob/dev-1.0/LICENSE",
-    "logo": "request-policy.png",
-    "privacy_url": "https://requestpolicycontinued.github.io/Privacy.html",
-    "source_url": "https://github.com/RequestPolicyContinued/requestpolicy",
-    "name": "Request Policy",
-    "tos_url": "",
-    "url": "https://requestpolicycontinued.github.io/",
-    "wikipedia_url": "",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Web Browser Addons"
-        ]
-      }
-    ],
-    "slug": "request-policy"
-  },
-  {
     "development_stage": "released",
     "description": "自由、安全的 P2P 通訊平台。",
     "license_url": "http://retroshare.sourceforge.net/wiki/index.php/Frequently_Asked_Questions#Is_RetroShare_Open_source.3F",


### PR DESCRIPTION
Closes #1866.

Should have been covered in #1815 but I missed the comment.

Removed with:

    find -name '*-projects.json' -print |
	while read file; do
	    jq '[.[] | select(.slug != "request-policy")]' < $file |
		sponge $file
	done