### PR TITLE
Switch to jsonlint2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "uglify-js": "^2.7.5"
   },
   "devDependencies": {
-    "jsonlint": "^1.6.2"
+    "jsonlint2": "^1.7.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
`jsonlint` is unmaintained and broken due to npm registry changes; see zaach/jsonlint#105. This will be failing all CI jobs that run in the near future, so we should fix it now.

I still need to update `package-lock.json` before this can be merged, self-assigning in an attempt not to forget.