### PR TITLE
Mark YaCy as experimental

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "بحث شبكي لامركزي.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Cerques web descentralitzades.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -5728,7 +5728,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Dezentralisierte Websuche.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Αποκεντρωμένες αναζητήσεις.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -6082,7 +6082,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Decentralized web search.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Malcentra TTT-serĉo.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -5725,7 +5725,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Búsquedas web descentralizadas.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "جستجوی غیرمتمرکز وب",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -5731,7 +5731,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Hakukone, jonka palvelimet sijaitsevat eri puolilla maailmaa.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -5727,7 +5727,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Recherche web décentralisée.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -5725,7 +5725,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "חיפוש רשת לא ריכוזי.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "विकेन्द्रित वेब खोज.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Descentrala sercho en la Interreto.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -5733,7 +5733,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Ricerca web decentralizzata.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "分散化されたウェブ検索。",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -5725,7 +5725,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Decentraal zoeken.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -5725,7 +5725,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Desentralisert nettsøk.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Zdecentralizowana wyszukiwarka.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Pesquisa web descentralizada.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -5735,7 +5735,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Децентрализованный веб поиск.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -5725,7 +5725,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Децентрализована интернет претрага.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -5725,7 +5725,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Decentralizovana internet pretraga.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -5725,7 +5725,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Decentraliserad webbsökning.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -5725,7 +5725,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "Gayri-merkezi web aramaları.",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -5754,7 +5754,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "去中心化的 Web 搜索。",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -5687,7 +5687,7 @@
     "slug": "wordpress"
   },
   {
-    "development_stage": "released",
+    "development_stage": "experimental",
     "description": "分散式的搜尋平台。",
     "license_url": "https://github.com/yacy/yacy_search_server/blob/master/COPYRIGHT",
     "logo": "yacy.png",


### PR DESCRIPTION
Unfortunately, YaCy is not ready for day-to-day use: search quality is very bad. For example, it can't find prism-break.org if I search for "prism break".

The concept is great but quality is so low that it perhaps warrants removal from the suggestions list according to "Quality over quantity" policy specified in PRISM Break's README file.
