### PR TITLE
Remove Facebook from Email categories

### DIFF
--- a/source/db/en-projects-rejected.ls
+++ b/source/db/en-projects-rejected.ls
@@ -309,9 +309,9 @@ projects-rejected =
     name: "Facebook"
     categories: [
       * name: "Web Services"
-        subcategories: ["Email Accounts", "Social Networks", "Video & Voice"]
+        subcategories: ["Social Networks", "Video & Voice"]
       * name: "Servers"
-        subcategories: ["Email Server", "Social Networks", "Video & Voice"]
+        subcategories: ["Social Networks", "Video & Voice"]
     ]
 
   * status: 'rejected'
@@ -930,7 +930,7 @@ projects-rejected =
       * name: "Servers"
         subcategories: ["Productivity"]
     ]
-	
+
   * status: 'rejected'
     tags: ["Proprietary"]
     logo: "roboform.png"
@@ -1217,7 +1217,7 @@ projects-rejected =
       * name: "Servers"
         subcategories: ["Instant Messaging"]
     ]
-	
+
   * status: 'rejected'
     tags: ["Proprietary"]
     logo: "mIRC.png"


### PR DESCRIPTION
While Facebook can conceivably used as an email service, it is not regarded as such and very few people use and/or know about this functionality. 

I think that putting Facebook in this category is confusing, hence this pull request.