### PR TITLE
Remove "web service" badge from Up1

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -5581,14 +5581,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -5901,14 +5901,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -5579,14 +5579,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -5584,14 +5584,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -5581,14 +5581,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -5579,14 +5579,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -5586,14 +5586,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -5579,14 +5579,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -5579,14 +5579,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -5587,14 +5587,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -5579,14 +5579,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -5579,14 +5579,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -5579,14 +5579,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -5579,14 +5579,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -5607,14 +5607,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -5545,14 +5545,35 @@
     ],
     "categories": [
       {
-        "name": "Servers",
+        "name": "GNU/Linux",
         "subcategories": [
           "Media Publishing",
           "Productivity"
         ]
       },
       {
-        "name": "Web Services",
+        "name": "BSD",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Windows",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "OS X",
+        "subcategories": [
+          "Media Publishing",
+          "Productivity"
+        ]
+      },
+      {
+        "name": "Servers",
         "subcategories": [
           "Media Publishing",
           "Productivity"


### PR DESCRIPTION
Up1 is not a centralized web service, but rather a self-hosted service. Currently there is a lot of inconsistency in usage of this badge, but it seems to me that the only meaningful distinction is to mark centralized web services.

Otherwise, all networking server-client software would have to be marked as "web service", because user will always use some particular instance of it (think of OpenVPN and multiple OpenVPN providers).

Notably, Kolab, Nextcloud, Riot are self-hosted services that currently do not have this badge. This pull request adds Up1 to the list.

Specifically compare Kolab (doesn't have "web service" badge) and Kolab Now (does have "web service" badge). I think this example captures the essence of when this badge is applicable.