### PR TITLE
Adopt Ruby code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+# Code of Conduct
+
+* Participants will be tolerant of opposing views.
+* Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
+* When interpreting the words and actions of others, participants should always assume good intentions.
+* Behaviour which can be reasonably considered harassment will not be tolerated.
+
 # Contribute: Projects
 
 ### Which Files to Edit
@@ -130,9 +137,3 @@ If you wish to mirror this site, [nylira/prism-break-static](https://github.com/
 
  - [https://www.sedrubal.de/service/prism-break/en/](https://www.sedrubal.de/service/prism-break/en/)
  (credit: [sedrubal](https://github.com/sedrubal))
-
-# Code of Conduct
-
-This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to honor this code.
-
-[code-of-conduct]: http://todogroup.org/opencodeofconduct/#PRISM-Break/abuse@prism-break.org


### PR DESCRIPTION
See: https://www.ruby-lang.org/en/conduct/

This is an alternative to #1790. The proposed code of conduct is used by Ruby interpreter and is similar in spirit to [Debian code of conduct](https://www.debian.org/code_of_conduct) and [Fedora code of conduct](https://docs.fedoraproject.org/fedora-project/project/code-of-conduct.html).

I think this code of conduct would be more approachable and readable (something we want so that people who participate actually read it) and also significantly less political/inflammatory than Open Code of Conduct that is currently being used.

This commit also moves Code of Conduct section from the very bottom to the very top of `CONTRIBUTING.md` so that more people will notice it.

/cc @alerque @hasufell @strugee @vyp