### PR TITLE
Link Freenode channel in README, resolves #1914

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,11 @@
-# Contribute: Projects
+If you want to contribute and have any questions whatsoever, join us
+[at #prism-break on Freenode][#freenode]. It's a great place to get
+help. Don't ask to ask, just send your question and someone will get
+back to you soon.
+
+[#freenode]: https://webchat.freenode.net/?channels=prism-break
+
+## Projects
 
 ### Which Files to Edit
 If you want to edit or add a project to PRISM Break, this data resides here:
@@ -117,7 +124,8 @@ Your newly translated site is available at './public/**language-code**/'. Visit 
 
 Remember to revert the `Makefile` change and then commit the changes and issue a pull request.
 
-# Contribute: Mirror
+## Mirrors
+
 If you wish to mirror this site, [nylira/prism-break-static](https://github.com/nylira/prism-break-static) is probably of interest to you. This is a completely static (but constantly updated) version of the site you can save to browse locally or serve over HTTP.
 
 ### Mirrors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 If you want to contribute and have any questions whatsoever, join us
-[at #prism-break on Freenode][#freenode]. It's a great place to get
-help. Don't ask to ask, just send your question and someone will get
-back to you soon.
+[at #prism-break on Freenode][#freenode]. It's a great place to get help. Don't
+ask to ask, just send your question and someone will get back to you soon.
 
 [#freenode]: https://webchat.freenode.net/?channels=prism-break
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ If you'd like to translate the project to your favorite language, there's no nee
 
 More information for translators can be found in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-Join us on IRC [at #fairphone channel on Freenode](https://webchat.freenode.net/?channels=prism-break)!
+Join us on IRC [at #prism-break channel on Freenode](https://webchat.freenode.net/?channels=prism-break)!
+Feel free to ask any questions.
 
 ## Project Inclusion Guidelines
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ If you'd like to translate the project to your favorite language, there's no nee
 
 More information for translators can be found in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-Join us on IRC [at #prism-break channel on Freenode][#prism-break]! Feel free to ask any questions.
+Join us on IRC [at #prism-break channel on Freenode][#prism-break]!
+Feel free to ask any questions.
 
 [#prism-break]: https://webchat.freenode.net/?channels=prism-break
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ If you'd like to translate the project to your favorite language, there's no nee
 
 More information for translators can be found in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-Join us on IRC [at #prism-break channel on Freenode](https://webchat.freenode.net/?channels=prism-break)!
-Feel free to ask any questions.
+Join us on IRC [at #prism-break channel on Freenode][#prism-break]! Feel free to ask any questions.
+
+[#prism-break]: https://webchat.freenode.net/?channels=prism-break
 
 ## Project Inclusion Guidelines
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ If you'd like to translate the project to your favorite language, there's no nee
 
 More information for translators can be found in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-Join us on IRC [at #prism-break channel on Freenode][#prism-break]!
-Feel free to ask any questions.
+Join us [at #prism-break on Freenode][#prism-break]! Feel free to ask any questions.
 
 [#prism-break]: https://webchat.freenode.net/?channels=prism-break
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ If you'd like to translate the project to your favorite language, there's no nee
 
 More information for translators can be found in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+Join us on IRC [at #fairphone channel on Freenode](https://webchat.freenode.net/?channels=prism-break)!
+
 ## Project Inclusion Guidelines
 
  - **Only F/OSS software is allowed to be featured on PRISM Break.**


### PR DESCRIPTION
This adds a direct qwebirc link to #prism-break IRC channel so that people that do not regularly use IRC can easily participate, without opening issues for questions.

/cc @strugee 