### PR TITLE
Drop GNUnet

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet ist ein 100% freies P2P-Netzwerk.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Git Service zum selber hosten, geschrieben in Go, einfach aufzusetzen.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -2061,55 +2061,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "notes": "",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet es una red P2P completamente libre.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -1867,54 +1867,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet on täysin vapaa P2P verkko.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -1866,54 +1866,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet est un réseau P2P entièrement libre.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://fr.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Service git auto-hébergé sans peine écrit en Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet היא רשת P2P חופשית לגמרי.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -1867,54 +1867,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet è una rete P2P completamente libera.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://it.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -1867,54 +1867,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Полностью свободная P2P сеть.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://ru.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet je potpuno besplatna P2P mreža.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet tamamen özgür bir P2P ağıdır.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -1940,54 +1940,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet 是一个完全自由的 P2P 网络。",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "可以轻松建立的你自己的用 Go 语言写的 Git 服务器。",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -1865,54 +1865,6 @@
   },
   {
     "development_stage": "released",
-    "description": "GNUnet is a fully free P2P network.",
-    "license_url": "https://gnunet.org/svn/gnunet/COPYING",
-    "logo": "gnunet.png",
-    "privacy_url": "",
-    "source_url": "https://gnunet.org/subversion",
-    "name": "GNUnet",
-    "tos_url": "",
-    "url": "https://gnunet.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/GNUnet",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "BSD",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "GNU/Linux",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "macOS",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      },
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Anonymizing Networks"
-        ]
-      }
-    ],
-    "slug": "gnunet"
-  },
-  {
-    "development_stage": "released",
     "description": "Painless self hosted git service written in Go.",
     "license_url": "https://github.com/gogits/gogs/blob/master/LICENSE",
     "logo": "gogs.png",


### PR DESCRIPTION
The project is practically dead. The latest release dates back to 2014, there has been zero activity in the repositories in the last 14 months: https://gnunet.org/git/