### PR TITLE
Drop Antiprism

### DIFF
--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -82,35 +82,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Live USB/memory card OpenELEC-based media server toolbox platform for securing the online presence, web browsing and communications.",
-    "license_url": "https://www.antiprism.ca/manual_en.html#LICENSE",
-    "logo": "antiprism.png",
-    "notes": "AntiPrism is a toolbox platform for securing the online presence, web browsing and communications. It is implemented as a set of extensions to the OpenELEC-derived media center software providing a universal and seamlessly integrated web privacy solution for home and small office. It runs from a read-only file system within a secure Linux operating environment bootable from a USB flash drive, SD memory card, or installable on a HDD/SSD. AntiPrism is activated with a password used as an encryption key to a hidden file system. Once deactivated, it leaves no traces of its operations. The computer device running AntiPrism can serve as a media center for watching movies, streaming music and games, and general web surfing with the included basic web browser, because the basic XBMC/Kodi external plug-ins functionalities are preserved and acting as an anonymizing tool in the background. Current AntiPrism version supports i386, x86_64 and ARM-compatible processors running on a wide range of Intel-compatible PCs and Raspberry Pi.",
-    "privacy_url": "",
-    "source_url": "https://github.com/antiprismca/OpenELEC-Antiprism",
-    "name": "AntiPrism",
-    "tos_url": "",
-    "url": "https://www.antiprism.ca/",
-    "wikipedia_url": "",
-    "protocols": [
-      "Tor",
-      "I2P",
-      "OTR",
-      "GPG"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Raspberry Pi",
-          "Operating Systems (Live)"
-        ]
-      }
-    ],
-    "slug": "antiprism"
-  },
-  {
-    "development_stage": "released",
     "description": "PBX implementation with VoIP/SIP support.",
     "license_url": "http://svnview.digium.com/svn/asterisk/trunk/LICENSE?view=markup",
     "logo": "asterisk.png",


### PR DESCRIPTION
Unfriendly to contributions, no public commit history, just squashed
release commits:

https://github.com/antiprismca/OpenELEC-Antiprism/commits/master

Haven't been updated for a long time (since early 2017), which
is very bad for a distribution. Large gaps between updates.

Not clear how this is any better than OpenELEC.