### PR TITLE
Drop DAVDroid in favor of Etesync

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "توزيعة جنو/لينكس شهيرة و أخلاقية.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Popular distribució de GNU/Linux famosa pel seu contracte social.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Populäre, ethische GNU/Linux-Distribution.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Δημοφιλής 'ηθική' διανομή GNU/Linux.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -624,33 +624,6 @@
   },
   {
     "development_stage": "released",
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "license_url": "https://github.com/bitfireAT/davdroid/blob/master/COPYING",
-    "logo": "davdroid.png",
-    "notes": "",
-    "privacy_url": "https://davdroid.bitfire.at/privacy",
-    "source_url": "https://github.com/bitfireAT/davdroid",
-    "name": "DAVdroid",
-    "tos_url": "",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "protocols": [
-      "CalDAV",
-      "CardDAV"
-    ],
-    "categories": [
-      {
-        "name": "Android",
-        "subcategories": [
-          "File Storage & Sync",
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "davdroid"
-  },
-  {
-    "development_stage": "released",
     "description": "Popular ethical GNU/Linux distribution.",
     "license_url": "http://www.debian.org/legal/licenses/",
     "logo": "debian.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Populara, etika distribuo GNU/Linux.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Popular distribución ética de GNU/Linux.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "توزیع محبوب گنو/لینوکس با اصول قاطع",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Erittäin suosittu ja eettinen GNU/Linux-jakelu.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid est une application open-source de synchronisation CalDAV/CardDAV pour Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Distribution GNU/Linux populaire et éthique.",
     "url": "https://www.debian.org/index.fr.html",
     "wikipedia_url": "https://fr.wikipedia.org/wiki/Debian",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "הפצת GNU/לינוקס מוסרית פופולרית.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "लोकप्रिय एथिकल जीएनयु/लिनक्स वितरण.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Populara, etika distributo GNU/Linux.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Distribuzione GNU/Linux famosa per il suo contratto sociale.",
     "url": "http://debian.org",
     "wikipedia_url": "https://it.wikipedia.org/wiki/Debian",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "人気の高い、ハッカー倫理にかなったGNU/Linuxディストリビューション。",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Populaire ethische GNU/Linux distributie.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Populær, etisk GNU/Linux-distribusjon.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Popularna dystrybucja GNU/Linux, bardzo stabilna i z etyką współpracy.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Distribuição GNU/Linux livre famosa por suas posições éticas.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Популярный GNU/Linux дистрибутив.",
     "url": "https://www.debian.org/index.ru.html",
     "wikipedia_url": "https://ru.wikipedia.org/wiki/Debian",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Популарне ГНУ/Линукс дистрибуције.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Popularne GNU/Linux distribucije.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Populär etisk GNU/Linux distribution.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "Popüler etik GNU/Linux dağıtımı.",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid 是一个开源的 CalDAV/CardDAV 同步 APP，支持 Android 4+。",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "流行的，作风正派的 GNU/Linux 发行版。",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -82,12 +82,6 @@
     "slug": "cryptsetup"
   },
   {
-    "description": "DAVdroid is an open-source CalDAV/CardDAV synchronization app for Android 4+.",
-    "url": "http://davdroid.bitfire.at/",
-    "wikipedia_url": "",
-    "slug": "davdroid"
-  },
-  {
     "description": "流行地、遵守開源倫理的 GNU/Linux 發行版。",
     "url": "http://debian.org",
     "wikipedia_url": "https://en.wikipedia.org/wiki/Debian",


### PR DESCRIPTION
We already list Etesync, which does the same thing as Davdroid while
being end-to-end encrypted, as in not leaking any data to the server.