### PR TITLE
Drop Openswan

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Client VPN de codi lliure.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -594,12 +594,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Freie VPN-Client-Software abgeleitet von FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Freier VPN-Client-Software.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -3999,29 +3999,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "license_url": "https://github.com/xelerance/Openswan/blob/master/COPYING",
-    "logo": "openswan.png",
-    "notes": "",
-    "privacy_url": "",
-    "source_url": "https://github.com/xelerance/Openswan",
-    "name": "Openswan",
-    "tos_url": "",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "VPN Servers"
-        ]
-      }
-    ],
-    "slug": "openswan"
-  },
-  {
-    "development_stage": "released",
     "description": "Free software VPN client.",
     "license_url": "https://github.com/OpenVPN/openvpn/blob/master/COPYING",
     "logo": "openvpn.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Cliente VPN libre derivado de FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Cliente VPN de software libre.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "کلاینت نرم‌افزار آزادی VPN",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -597,12 +597,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Vapaa FreeS/WAN pohjainen VPN asiakasohjelma.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Vapaa VPN asiakasohjelmisto.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -595,12 +595,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Client VPN libre dérivé de FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Client VPN libre.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://fr.wikipedia.org/wiki/OpenVPN",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "לקוח VPN חופשי הנגזר מ-FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "לקוח VPN חופשי.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -598,12 +598,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Client VPN libero derivato da FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Client VPN libero.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://it.wikipedia.org/wiki/OpenVPN",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Vrije software VPN client afgeleid van FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Vrije software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Fri VPN-klient.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -599,12 +599,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Свободный VPN клиент, основанный на FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Свободный VPN клиент.",
     "url": "https://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://ru.wikipedia.org/wiki/OpenVPN",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Свободный VPN клиент, основанный на FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Свободный VPN клиент, основанный на FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Besplatan VPN kliejnt.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Özgür yazılım VPN istemcisi, FreeS/WAN devşirmesi.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Özgür yazılım VPN istemcisi.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -604,12 +604,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "自由的 VPN 客户端，FreeS/WAN 的衍生品。",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "自由的 VPN 客户端。",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -593,12 +593,6 @@
     "slug": "openstreetmap"
   },
   {
-    "description": "Free software VPN client derived from FreeS/WAN.",
-    "url": "https://www.openswan.org/projects/openswan/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Openswan",
-    "slug": "openswan"
-  },
-  {
     "description": "Free software VPN client.",
     "url": "http://openvpn.net/index.php/open-source.html",
     "wikipedia_url": "https://en.wikipedia.org/wiki/OpenVPN",


### PR DESCRIPTION
Openswan has not been updated for the most part since 2017:
https://github.com/xelerance/Openswan/commits/master

Strongswan does the same thing but is way better maintained:
https://github.com/strongswan/strongswan