### PR TITLE
Drop DiskCryptor

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "Sehr leistungshähige Software zur Partitionsverschlüsseung für Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "Ein Tool, mit dem eine sichere Kommunikation zwischen Client und DNS Resolver sichergestelllt wird.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -800,29 +800,6 @@
   },
   {
     "development_stage": "released",
-    "description": "High performance partition encryption software for Windows.",
-    "license_url": "https://diskcryptor.net/wiki/Main_Page",
-    "logo": "diskcryptor.png",
-    "notes": "",
-    "privacy_url": "",
-    "source_url": "https://diskcryptor.net/wiki/Downloads",
-    "name": "DiskCryptor",
-    "tos_url": "",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "Windows",
-        "subcategories": [
-          "Disk Encryption"
-        ]
-      }
-    ],
-    "slug": "diskcryptor"
-  },
-  {
-    "development_stage": "released",
     "description": "Secure communications between a client and a DNS resolver.",
     "license_url": "https://github.com/jedisct1/dnscrypt-proxy/blob/master/LICENSE",
     "logo": "dnscrypt.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "Software de alto rendimiento para cifrado de particiones en Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "Herramienta para asegurar comunicaciones entre un cliente y un solucionador de DNS.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "Suorituskykyinen osioita salaava ohjelmisto Windows:ille.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "Työkalu joka salaa yhteyden käyttäjän ja DNS resolverin välillä.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "Logiciel de chiffrement à haute performance pour Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "Un outil pour sécuriser les communications entre un client et un résolveur DNS.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "כלי לאבטחת תקשורת בין תוכנת לקוח ונתב DNS&#8206.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "Software ad alte prestazioni per criptare partizioni su Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "Strumento per proteggere le comunicazioni tra client e resolver DNS.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "Высокопроизводительное программное обеспечение для шифрования разделов под Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page/ru",
-    "wikipedia_url": "https://ru.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "Утилита для безопасной коммуникации между клиентом и DNS резолвером.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "Bir kullanıcı ve DNS servisi arasındaki bağlantıyı şifreleyen bir araç",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "Windows 系统下高效的磁盘加密工具。",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "一个保障客户端与 DNS 服务器通讯安全的软件。",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -107,12 +107,6 @@
     "slug": "diaspora"
   },
   {
-    "description": "High performance partition encryption software for Windows.",
-    "url": "https://diskcryptor.net/wiki/Main_Page",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/DiskCryptor",
-    "slug": "diskcryptor"
-  },
-  {
     "description": "A tool to secure communications between a client and a DNS resolver.",
     "url": "https://dnscrypt.info",
     "wikipedia_url": "",


### PR DESCRIPTION
Windows only. Last release dates back to 09.07.2014. Does not support EFI boot or GPT labels, if one uses it on such system, makes it unbootable. Does not support non-alphanumeric passwords.

See: https://diskcryptor.net/wiki/Main_Page