### PR TITLE
Drop Semantic Scuttle

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -694,12 +694,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -4388,29 +4388,6 @@
   },
   {
     "development_stage": "experimental",
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "license_url": "https://github.com/cweiske/SemanticScuttle/blob/master/www/about.php",
-    "logo": "semanticscuttle.png",
-    "notes": "",
-    "privacy_url": "",
-    "source_url": "https://github.com/cweiske/SemanticScuttle",
-    "name": "SemanticScuttle",
-    "tos_url": "",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "protocols": [],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Bookmark Sync"
-        ]
-      }
-    ],
-    "slug": "semanticscuttle"
-  },
-  {
-    "development_stage": "experimental",
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "license_url": "https://github.com/shaarli/Shaarli/blob/master/COPYING",
     "logo": "shaarli.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -693,12 +693,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -697,12 +697,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -695,12 +695,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -693,12 +693,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -698,12 +698,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -693,12 +693,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -693,12 +693,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -699,12 +699,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -693,12 +693,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -693,12 +693,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -693,12 +693,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -693,12 +693,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -697,12 +697,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle 是一个社会书签工具，提供结构化标签和协作标签描述之类的试验性功能。",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "个人的、最小化的、超快的无数据库的书签同步工具。",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -687,12 +687,6 @@
     "slug": "salut-a-toi"
   },
   {
-    "description": "SemanticScuttle is a social bookmarking tool experimenting with features like structured tags and collaborative tag descriptions.",
-    "url": "http://semanticscuttle.sourceforge.net/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Scuttle_(software)",
-    "slug": "semanticscuttle"
-  },
-  {
     "description": "The personal, minimalist, super-fast, no-database delicious clone.",
     "url": "https://github.com/shaarli/Shaarli/",
     "wikipedia_url": "",


### PR DESCRIPTION
Last release was on 2013-03-20:
https://sourceforge.net/projects/semanticscuttle/files/SemanticScuttle/v0.98/