### PR TITLE
Remove Etherpad

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "وثائق  تعاونيّة،  مفتوحة  المصدر في  الوقت  الحقيقي.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "تطبيق يوميّة  وبريد  إلكتروني  مجاني .",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Documents col·laboratius en temps real, de codi obert.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Aplicació de correu electrònico i calendari lliure.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Quelloffenes, gemeinsames Arbeiten an Textdokumenten in Echtzeit.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "Das Etherpad-Projekt unterhält eine Liste von [Seiten, die Etherpad-Dienste](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite) anbieten. Bitte wähle daraus nur Dienste, die SSL/HTTPS anbieten und informiere dich über den Hintergrund des Anbieters, bevor du ihm deine Daten anvertraust.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://de.wikipedia.org/wiki/EtherPad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Email, Adressbuch und Kalenderanwendung für das GNOME-Desktop mit PGP-Unterstützung.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Ανοιχτού κώδικα, συνεργατικά έγγραφα πραγματικού χρόνου.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Ελεύθερο πρόγραμμα email και ημερολογίου.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -1462,37 +1462,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Self-hosted, real-time collaborative documents.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Email, address book, and calendar application for the GNOME desktop with PGP support.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Malfermitkoda, kunlaboraj dokumentoj en reala tempo.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Libera programo por retpoŝtoj kaj kalendaroj kun subteno por GPG.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Documentos colaborativos en tiempo real, de software libre.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://es.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Aplicación libre de correo electrónico, contactos y calendario para el escritorio GNOME. Con soporte para PGP.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "نگارش مشارکتی اسناد همزمان و متن‌باز",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "برنامه آزاد ایمیل و تقویم",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Avoimen lähdekoodin reaaliaikaiset yhteistyöasiakirjat.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "Etherpad projekti ylläpitää listaa [sivuista jotka tarjoavat etherpad palveluita](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Valitse ainoastaan SSL tuettu palvelu, ja tutki sivuston taustaa ennen kuin uskot heille informaatiota.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Vapaa sähköposti- ja kalenterisovellus.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Collaboration sur les documents en temps réel et open-source.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://fr.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Application libre de messagerie et de calendrier.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "שיתוף קבצים באחסון עצמאי ובזמן אמת.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "יישום אימייל ולוח שנה חופשי עם תמיכת GPG.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "आेपन सोर्स, समयोचित सहभागी दस्तावेज.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "जीपीजी समर्थित मुक्त ईमेल एवं केलेन्ड़र अनुप्रयोग.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Kunlaboral dokumenti de apertita fontokodo en reala tempo.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Libera programo por retposhti e kalendari kun suporto por GPG.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Sistema autogestito per documenti collaborativi in tempo reale.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "Il progetto etherpad mantiene una lista di [siti che ospitano servizi etherpad](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Si consiglia di scegliere solo servizi che usano SSL e controllare la storia del sito prima di affidare loro i tuoi dati.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Client email, rubrica e calendario per desktop GNOME, con supporto PGP.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "オープンソースで、リアルタイムの協働文書作成を実現。",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "自由な電子メールおよびカレンダーアプリケーション。",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Open source, realtime samenwerken aan documenten.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://nl.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Vrije e-mail en agenda applicatie met GPG ondersteuning.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Dokumentsamskriving i sanntid basert på fri programvare.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Fri e-post- og kalenderapplikasjon.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Serwer edytora testów z multilogowaniem.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://pl.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Darmowa aplikacja ze wsparciem dla GPG i zaawanasowanym terminarzem.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Documentos colaborativos em tempo real, ferramenta de código aberto.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Aplicativo livre de email e calendário.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Приложение для работы с документами в реальном времени.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "Проект etherpad публикует [список сайтов, которые используют etherpad](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Выбирайте те сервисы, которые используют SSL и узнайте больше о сайте, перед тем, как доверять ему свои данные.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Приложение электронной почты, адресной книги и календаря для GNOME с поддержкой PGP.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Коолаборација документима у реалном времену.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Бесплатна емаил и календар апликација са ГПГ подршком.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Koolaboracija dokumentima u realnom vremenu.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Besplatna email i kalendar aplikacija sa GPG podrškom.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Dokumentsamarbete i realtid, öppen källkod.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "Gratis e-post och kalender klient.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Bireysel sunucuda, anlık belge işbirliği.",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "GNOME masaüstü için PGP destekli e-posta, adres defteri, takvim uygulaması.",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -1315,37 +1315,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Riseup 运营的共享编辑平台，也可以自行架设。",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "etherpad项目包含一个[提供共享编辑服务的网站清单](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite)。请选择支持 SSL 加密链接的站点，并且，在你把数据交给他们之前，最好查一下网站的背景。",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "支持 GPG 加密的 GNOME 桌面程序，包括 Email、通讯录、日历等。",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -1241,37 +1241,6 @@
   },
   {
     "development_stage": "released",
-    "description": "開放源碼、即時協作文書軟體。",
-    "license_url": "https://github.com/ether/etherpad-lite/blob/develop/LICENSE",
-    "logo": "etherpad.png",
-    "notes": "The etherpad project maintains a list of [sites that run etherpad services](https://github.com/ether/etherpad-lite/wiki/Sites-that-run-Etherpad-Lite). Please only choose from the services that use SSL, and research the site's background before trusting them with your data.",
-    "privacy_url": "",
-    "source_url": "https://github.com/ether/etherpad-lite",
-    "name": "Etherpad",
-    "tos_url": "",
-    "url": "http://etherpad.org/",
-    "wikipedia_url": "https://en.wikipedia.org/wiki/Etherpad",
-    "protocols": [
-      "SSL/TLS"
-    ],
-    "categories": [
-      {
-        "name": "Servers",
-        "subcategories": [
-          "Productivity"
-        ]
-      },
-      {
-        "name": "Web Services",
-        "subcategories": [
-          "Productivity"
-        ]
-      }
-    ],
-    "slug": "etherpad"
-  },
-  {
-    "development_stage": "released",
     "description": "自由的郵件與行事曆程式。",
     "license_url": "https://git.gnome.org/browse/evolution/tree/COPYING",
     "logo": "evolution.png",


### PR DESCRIPTION
Now that we list a comparable zero-knowledge service (Cryptpad), we shouldn't encourage Etherpad because it requires trusting server with plain text data.