### PR TITLE
Drop Onion Browser, see #1998

### DIFF
--- a/source/db/ar-projects.json
+++ b/source/db/ar-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/ca-projects.json
+++ b/source/db/ca-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/de-projects.json
+++ b/source/db/de-projects.json
@@ -3467,31 +3467,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Sicherer auf iOS-Geräten durch's Netz surfen mittels Tor.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain ist eine OpenPGP-Implementierung für Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/el-projects.json
+++ b/source/db/el-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/en-projects.json
+++ b/source/db/en-projects.json
@@ -3864,32 +3864,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "notes": "",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/eo-projects.json
+++ b/source/db/eo-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/es-projects.json
+++ b/source/db/es-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Navega la web a través de la red de Tor con este navegador de software libre para iOS.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/fa-projects.json
+++ b/source/db/fa-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/fi-projects.json
+++ b/source/db/fi-projects.json
@@ -3470,31 +3470,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Selaa verkkoa Tor-reitityksen kautta. iOS laitteille.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain on OpenPGP implementaatio Androidille.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/fr-projects.json
+++ b/source/db/fr-projects.json
@@ -3468,31 +3468,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surfer sur le Web à travers le réseau Tor avec ce navigateur open-source pour iOS.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain est une implémentation d'OpenPGP pour Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/he-projects.json
+++ b/source/db/he-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/hi-projects.json
+++ b/source/db/hi-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/io-projects.json
+++ b/source/db/io-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/it-projects.json
+++ b/source/db/it-projects.json
@@ -3472,31 +3472,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Naviga in internet attraverso la rete Tor con questo browser open source per iOS.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain è un’implementazione OpenPGP per Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/ja-projects.json
+++ b/source/db/ja-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/nl-projects.json
+++ b/source/db/nl-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/no-projects.json
+++ b/source/db/no-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/pl-projects.json
+++ b/source/db/pl-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/pt-projects.json
+++ b/source/db/pt-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/ru-projects.json
+++ b/source/db/ru-projects.json
@@ -3473,31 +3473,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Просматривайте веб-страницы через сеть Tor используя этот браузер с открытым исходным кодом для устройств с iOS.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "Реализация OpenPGP для Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/sr-Cyrl-projects.json
+++ b/source/db/sr-Cyrl-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Сигурно претраживање за иОС.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/sr-projects.json
+++ b/source/db/sr-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Sigurno pretraživanje za iOS.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/sv-projects.json
+++ b/source/db/sv-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/tr-projects.json
+++ b/source/db/tr-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "iOS'lu cihazlar için bu açık kaynaklı tarayıcı sayesinde web'de Tor ağı üzerinden gezin.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/zh-CN-projects.json
+++ b/source/db/zh-CN-projects.json
@@ -3544,31 +3544,6 @@
   },
   {
     "development_stage": "released",
-    "description": "IOS 平台上的开源浏览器，基于 Tor。",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain 是安卓平台上的 OpenPGP 实现。",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",

--- a/source/db/zh-TW-projects.json
+++ b/source/db/zh-TW-projects.json
@@ -3466,31 +3466,6 @@
   },
   {
     "development_stage": "released",
-    "description": "Surf the web through the Tor network with this open source browser for iOS devices.",
-    "license_url": "https://github.com/mtigas/iOS-OnionBrowser/blob/master/LICENSE",
-    "logo": "onion-browser.png",
-    "privacy_url": "",
-    "source_url": "https://github.com/mtigas/iOS-OnionBrowser",
-    "name": "Onion Browser",
-    "tos_url": "",
-    "url": "https://mike.tig.as/onionbrowser/",
-    "wikipedia_url": "",
-    "protocols": [
-      "SSL/TLS",
-      "Tor"
-    ],
-    "categories": [
-      {
-        "name": "iOS",
-        "subcategories": [
-          "Web Browsers"
-        ]
-      }
-    ],
-    "slug": "onion-browser"
-  },
-  {
-    "development_stage": "released",
     "description": "OpenKeychain is an OpenPGP implementation for Android.",
     "license_url": "https://github.com/open-keychain/open-keychain/blob/master/LICENSE",
     "logo": "open-keychain.png",


### PR DESCRIPTION
See #1998. Onion Browser is nonfree (distribution in binary form is not allowed), but source code is available. I think we should replace it with some other Tor browser for iOS (skimming through GitHub search, I found at least one).

I feel that nonfree apps with source availability but limited distribution are an interesting corner case for this list, so please let's discuss. cc @Atavic @Hillside502 @quantumpacket @strugee @Zegnat 